### PR TITLE
XMDEV-536: Adds graphQL type definitions

### DIFF
--- a/packages/backend/src/graphql/schema/builder.ts
+++ b/packages/backend/src/graphql/schema/builder.ts
@@ -2,7 +2,6 @@ import SchemaBuilder from "@pothos/core";
 import RelayPlugin from "@pothos/plugin-relay";
 import type { GraphQLContext } from "../context";
 
-// Create the schema builder with proper typing
 export const builder = new SchemaBuilder<{
   Context: GraphQLContext;
   Scalars: {
@@ -39,29 +38,18 @@ builder.scalarType("DateTime", {
   },
 });
 
-// Query root type
+// Query root type (fields will be added in queries/)
 builder.queryType({
   fields: (t) => ({
     hello: t.string({
       resolve: () => "Hello from GraphQL!",
     }),
-
-    // Test database connection
-    deviceCount: t.int({
-      resolve: async (_root, _args, ctx) => {
-        const result = await ctx.db.execute(
-          'SELECT COUNT(*) as count FROM "DEVICE"'
-        );
-        return Number(result[0].count);
-      },
-    }),
   }),
 });
 
-// Mutation root type (for future use)
+// Mutation root type
 builder.mutationType({
   fields: (t) => ({
-    // Placeholder - we'll add mutations later
     _placeholder: t.string({
       resolve: () => "Mutations will be added here",
     }),

--- a/packages/backend/src/graphql/schema/index.ts
+++ b/packages/backend/src/graphql/schema/index.ts
@@ -7,6 +7,7 @@ import "./types/band";
 import "./types/combo";
 import "./types/feature";
 import "./types/provider";
+import './types/junctions';
 import "./types/capability-results";
 
 // Build and export the schema

--- a/packages/backend/src/graphql/schema/index.ts
+++ b/packages/backend/src/graphql/schema/index.ts
@@ -1,7 +1,13 @@
 import { builder } from "./builder";
 
-// Import all type definitions (we'll create these in next tasks)
-// For now, we just have the basic Query and Mutation types from builder
+// Import all type definitions
+import "./types/device";
+import "./types/software";
+import "./types/band";
+import "./types/combo";
+import "./types/feature";
+import "./types/provider";
+import "./types/capability-results";
 
 // Build and export the schema
 export const schema = builder.toSchema();

--- a/packages/backend/src/graphql/schema/types/band.ts
+++ b/packages/backend/src/graphql/schema/types/band.ts
@@ -1,14 +1,13 @@
 import { builder } from "../builder";
 import { DeviceType } from "./device";
+import { DeviceBandType, ProviderDeviceBandType } from "./junctions";
 
-// Technology enum for bands
 export const TechnologyType = builder.enumType("Technology", {
   values: ["GSM", "HSPA", "LTE", "NR"] as const,
 });
 
-// Band type definition
 export const BandType = builder.objectRef<{
-  bandId: number;
+  id: number;
   bandNumber: string;
   technology: string;
   dlBandClass: string;
@@ -17,13 +16,9 @@ export const BandType = builder.objectRef<{
 
 BandType.implement({
   fields: (t) => ({
-    id: t.exposeID("bandId"),
-    bandNumber: t.exposeString("bandNumber", {
-      description: 'Band number (e.g., "2", "4", "n77")',
-    }),
-    technology: t.exposeString("technology", {
-      description: "Technology type (GSM, HSPA, LTE, NR)",
-    }),
+    id: t.exposeID("id"),
+    bandNumber: t.exposeString("bandNumber"),
+    technology: t.exposeString("technology"),
     dlBandClass: t.exposeString("dlBandClass", {
       nullable: true,
       description: "Downlink bandwidth class for the band",
@@ -33,18 +28,36 @@ BandType.implement({
       description: "Uplink bandwidth class for the band",
     }),
 
-    // Relationships
+    // Simple list of devices (backwards compatible)
     devices: t.field({
       type: [DeviceType],
-      description: "Devices that support this band (global capability)",
+      description: "Devices that support this band (simplified)",
       args: {
-        providerId: t.arg.id({
-          required: false,
-          description: "Filter by provider-specific support",
-        }),
+        providerId: t.arg.id({ required: false }),
       },
       resolve: async (_band, _args, _ctx) => {
-        // Will implement with repository
+        return [];
+      },
+    }),
+
+    // Detailed device support with junction data
+    deviceSupport: t.field({
+      type: [DeviceBandType],
+      description: "Detailed device/software/band relationships (global)",
+      resolve: async (_band, _args, _ctx) => {
+        return [];
+      },
+    }),
+
+    // Provider-specific detailed support
+    providerDeviceSupport: t.field({
+      type: [ProviderDeviceBandType],
+      description:
+        "Detailed device/software/band relationships (provider-specific)",
+      args: {
+        providerId: t.arg.id({ required: false }),
+      },
+      resolve: async (_band, _args, _ctx) => {
         return [];
       },
     }),

--- a/packages/backend/src/graphql/schema/types/band.ts
+++ b/packages/backend/src/graphql/schema/types/band.ts
@@ -11,8 +11,8 @@ export const BandType = builder.objectRef<{
   bandId: number;
   bandNumber: string;
   technology: string;
-  frequencyRange: string;
-  bandClass: string | null;
+  dlBandClass: string;
+  ulBandClass: string;
 }>("Band");
 
 BandType.implement({
@@ -24,12 +24,13 @@ BandType.implement({
     technology: t.exposeString("technology", {
       description: "Technology type (GSM, HSPA, LTE, NR)",
     }),
-    frequencyRange: t.exposeString("frequencyRange", {
-      description: "Frequency range in MHz",
-    }),
-    bandClass: t.exposeString("bandClass", {
+    dlBandClass: t.exposeString("dlBandClass", {
       nullable: true,
-      description: 'Band class/name (e.g., "PCS", "AWS", "C-Band")',
+      description: "Downlink bandwidth class for the band",
+    }),
+    ulBandClass: t.exposeString("ulBandClass", {
+      nullable: true,
+      description: "Uplink bandwidth class for the band",
     }),
 
     // Relationships

--- a/packages/backend/src/graphql/schema/types/band.ts
+++ b/packages/backend/src/graphql/schema/types/band.ts
@@ -1,0 +1,51 @@
+import { builder } from "../builder";
+import { DeviceType } from "./device";
+
+// Technology enum for bands
+export const TechnologyType = builder.enumType("Technology", {
+  values: ["GSM", "HSPA", "LTE", "NR"] as const,
+});
+
+// Band type definition
+export const BandType = builder.objectRef<{
+  bandId: number;
+  bandNumber: string;
+  technology: string;
+  frequencyRange: string;
+  bandClass: string | null;
+}>("Band");
+
+BandType.implement({
+  fields: (t) => ({
+    id: t.exposeID("bandId"),
+    bandNumber: t.exposeString("bandNumber", {
+      description: 'Band number (e.g., "2", "4", "n77")',
+    }),
+    technology: t.exposeString("technology", {
+      description: "Technology type (GSM, HSPA, LTE, NR)",
+    }),
+    frequencyRange: t.exposeString("frequencyRange", {
+      description: "Frequency range in MHz",
+    }),
+    bandClass: t.exposeString("bandClass", {
+      nullable: true,
+      description: 'Band class/name (e.g., "PCS", "AWS", "C-Band")',
+    }),
+
+    // Relationships
+    devices: t.field({
+      type: [DeviceType],
+      description: "Devices that support this band (global capability)",
+      args: {
+        providerId: t.arg.id({
+          required: false,
+          description: "Filter by provider-specific support",
+        }),
+      },
+      resolve: async (_band, _args, _ctx) => {
+        // Will implement with repository
+        return [];
+      },
+    }),
+  }),
+});

--- a/packages/backend/src/graphql/schema/types/capability-results.ts
+++ b/packages/backend/src/graphql/schema/types/capability-results.ts
@@ -1,0 +1,56 @@
+import { builder } from "../builder";
+import { DeviceType } from "./device";
+import { SoftwareType } from "./software";
+import { ProviderType } from "./provider";
+
+// Support status enum
+export const SupportStatusType = builder.enumType("SupportStatus", {
+  values: {
+    GLOBAL: {
+      value: "global",
+      description: "Globally supported across all providers",
+    },
+    PROVIDER_SPECIFIC: {
+      value: "provider-specific",
+      description: "Supported only by specific providers",
+    },
+  } as const,
+});
+
+// Result type for capability queries
+// Used when searching for devices by band/combo/feature
+export const DeviceCapabilityResultType = builder.objectRef<{
+  device: any; // Will be typed properly
+  software: any[];
+  supportStatus: "global" | "provider-specific";
+  provider: any | null;
+}>("DeviceCapabilityResult");
+
+DeviceCapabilityResultType.implement({
+  fields: (t) => ({
+    device: t.field({
+      type: DeviceType,
+      description: "The device that supports this capability",
+      resolve: (result) => result.device,
+    }),
+
+    software: t.field({
+      type: [SoftwareType],
+      description: "Software versions that support this capability",
+      resolve: (result) => result.software,
+    }),
+
+    supportStatus: t.field({
+      type: SupportStatusType,
+      description: "Whether this is global or provider-specific support",
+      resolve: (result) => result.supportStatus,
+    }),
+
+    provider: t.field({
+      type: ProviderType,
+      nullable: true,
+      description: "Provider (if provider-specific)",
+      resolve: (result) => result.provider,
+    }),
+  }),
+});

--- a/packages/backend/src/graphql/schema/types/capability-results.ts
+++ b/packages/backend/src/graphql/schema/types/capability-results.ts
@@ -20,10 +20,10 @@ export const SupportStatusType = builder.enumType("SupportStatus", {
 // Result type for capability queries
 // Used when searching for devices by band/combo/feature
 export const DeviceCapabilityResultType = builder.objectRef<{
-  device: any; // Will be typed properly
-  software: any[];
+  device: any; // eslint-disable-line @typescript-eslint/no-explicit-any -- will be typed properly
+  software: any[]; // eslint-disable-line @typescript-eslint/no-explicit-any
   supportStatus: "global" | "provider-specific";
-  provider: any | null;
+  provider: any | null; // eslint-disable-line @typescript-eslint/no-explicit-any
 }>("DeviceCapabilityResult");
 
 DeviceCapabilityResultType.implement({

--- a/packages/backend/src/graphql/schema/types/combo.ts
+++ b/packages/backend/src/graphql/schema/types/combo.ts
@@ -1,6 +1,11 @@
 import { builder } from "../builder";
-import { BandType } from "./band";
 import { DeviceType } from "./device";
+import { BandType } from "./band";
+import {
+  DeviceComboType,
+  ProviderDeviceComboType,
+  ComboBandType,
+} from "./junctions";
 
 // Combo technology enum
 export const ComboTechnologyType = builder.enumType("ComboTechnology", {
@@ -20,16 +25,15 @@ export const ComboTechnologyType = builder.enumType("ComboTechnology", {
   } as const,
 });
 
-// Combo type definition
 export const ComboType = builder.objectRef<{
-  comboId: number;
+  id: number;
   name: string;
   technology: string;
 }>("Combo");
 
 ComboType.implement({
   fields: (t) => ({
-    id: t.exposeID("comboId"),
+    id: t.exposeID("id"),
     name: t.exposeString("name", {
       description: 'Combo name (e.g., "2A-4A", "B2-n66")',
     }),
@@ -37,27 +41,54 @@ ComboType.implement({
       description: "Combo technology type",
     }),
 
-    // Relationships
+    // Simple list of bands (backwards compatible)
     bands: t.field({
       type: [BandType],
-      description: "Bands that make up this combo (in order)",
+      description: "Bands that make up this combo (ordered)",
       resolve: async (_combo, _args, _ctx) => {
-        // Will implement with DataLoader
         return [];
       },
     }),
 
+    // Detailed band composition with position
+    bandComponents: t.field({
+      type: [ComboBandType],
+      description: "Detailed band components with position information",
+      resolve: async (_combo, _args, _ctx) => {
+        return [];
+      },
+    }),
+
+    // Simple list of devices
     devices: t.field({
       type: [DeviceType],
-      description: "Devices that support this combo",
+      description: "Devices that support this combo (simplified)",
       args: {
-        providerId: t.arg.id({
-          required: false,
-          description: "Filter by provider-specific support",
-        }),
+        providerId: t.arg.id({ required: false }),
       },
       resolve: async (_combo, _args, _ctx) => {
-        // Will implement with repository
+        return [];
+      },
+    }),
+
+    // Detailed device support
+    deviceSupport: t.field({
+      type: [DeviceComboType],
+      description: "Detailed device/software/combo relationships (global)",
+      resolve: async (_combo, _args, _ctx) => {
+        return [];
+      },
+    }),
+
+    // Provider-specific detailed support
+    providerDeviceSupport: t.field({
+      type: [ProviderDeviceComboType],
+      description:
+        "Detailed device/software/combo relationships (provider-specific)",
+      args: {
+        providerId: t.arg.id({ required: false }),
+      },
+      resolve: async (_combo, _args, _ctx) => {
         return [];
       },
     }),

--- a/packages/backend/src/graphql/schema/types/combo.ts
+++ b/packages/backend/src/graphql/schema/types/combo.ts
@@ -1,0 +1,65 @@
+import { builder } from "../builder";
+import { BandType } from "./band";
+import { DeviceType } from "./device";
+
+// Combo technology enum
+export const ComboTechnologyType = builder.enumType("ComboTechnology", {
+  values: {
+    LTE_CA: {
+      value: "LTE CA",
+      description: "LTE Carrier Aggregation",
+    },
+    EN_DC: {
+      value: "EN-DC",
+      description: "E-UTRA-NR Dual Connectivity",
+    },
+    NR_CA: {
+      value: "NR CA",
+      description: "NR Carrier Aggregation",
+    },
+  } as const,
+});
+
+// Combo type definition
+export const ComboType = builder.objectRef<{
+  comboId: number;
+  name: string;
+  technology: string;
+}>("Combo");
+
+ComboType.implement({
+  fields: (t) => ({
+    id: t.exposeID("comboId"),
+    name: t.exposeString("name", {
+      description: 'Combo name (e.g., "2A-4A", "B2-n66")',
+    }),
+    technology: t.exposeString("technology", {
+      description: "Combo technology type",
+    }),
+
+    // Relationships
+    bands: t.field({
+      type: [BandType],
+      description: "Bands that make up this combo (in order)",
+      resolve: async (_combo, _args, _ctx) => {
+        // Will implement with DataLoader
+        return [];
+      },
+    }),
+
+    devices: t.field({
+      type: [DeviceType],
+      description: "Devices that support this combo",
+      args: {
+        providerId: t.arg.id({
+          required: false,
+          description: "Filter by provider-specific support",
+        }),
+      },
+      resolve: async (_combo, _args, _ctx) => {
+        // Will implement with repository
+        return [];
+      },
+    }),
+  }),
+});

--- a/packages/backend/src/graphql/schema/types/device.ts
+++ b/packages/backend/src/graphql/schema/types/device.ts
@@ -1,0 +1,145 @@
+import { builder } from "../builder";
+import { SoftwareType } from "./software";
+import { BandType } from "./band";
+import { ComboType } from "./combo";
+import { FeatureType } from "./feature";
+
+export const DeviceType = builder.objectRef<{
+  id: number;
+  vendor: string;
+  modelNum: string;
+  marketName: string | null;
+  releaseDate: string;
+  createdAt: Date;
+  updatedAt: Date;
+}>("Device");
+
+DeviceType.implement({
+  fields: (t) => ({
+    id: t.exposeID("id"),
+    vendor: t.exposeString("vendor"),
+    modelNum: t.exposeString("modelNum"),
+    marketName: t.exposeString("marketName", { nullable: true }),
+    releaseDate: t.expose("releaseDate", {
+      type: "DateTime",
+      description: "Device release date",
+    }),
+    createdAt: t.expose("createdAt", { type: "DateTime" }),
+    updatedAt: t.expose("updatedAt", { type: "DateTime" }),
+
+    // Software versions
+    software: t.field({
+      type: [SoftwareType],
+      description: "All software versions for this device",
+      args: {
+        platform: t.arg.string({
+          required: false,
+          description: "Filter by platform (iOS, Android)",
+        }),
+        releasedAfter: t.arg({
+          type: "DateTime",
+          required: false,
+          description: "Filter by release date",
+        }),
+      },
+      resolve: async (_device, _args, _ctx) => {
+        // Will implement in next task
+        return [];
+      },
+    }),
+
+    // Global band support
+    supportedBands: t.field({
+      type: [BandType],
+      description: "Bands supported globally by this device",
+      args: {
+        technology: t.arg.string({
+          required: false,
+          description: "Filter by technology (GSM, HSPA, LTE, NR)",
+        }),
+        softwareId: t.arg.id({
+          required: false,
+          description: "Filter by specific software version",
+        }),
+      },
+      resolve: async (_device, _args, _ctx) => {
+        // Will implement in next task
+        return [];
+      },
+    }),
+
+    // Provider-specific band support
+    supportedBandsForProvider: t.field({
+      type: [BandType],
+      description: "Bands supported by this device for a specific provider",
+      args: {
+        providerId: t.arg.id({ required: true }),
+        technology: t.arg.string({ required: false }),
+        softwareId: t.arg.id({ required: false }),
+      },
+      resolve: async (_device, _args, _ctx) => {
+        // Will implement in next task
+        return [];
+      },
+    }),
+
+    // Global combo support
+    supportedCombos: t.field({
+      type: [ComboType],
+      description: "Combos supported globally by this device",
+      args: {
+        technology: t.arg.string({
+          required: false,
+          description: "Filter by technology (LTE CA, EN-DC, NR CA)",
+        }),
+        softwareId: t.arg.id({ required: false }),
+      },
+      resolve: async (_device, _args, _ctx) => {
+        // Will implement in next task
+        return [];
+      },
+    }),
+
+    // Provider-specific combo support
+    supportedCombosForProvider: t.field({
+      type: [ComboType],
+      description: "Combos supported by this device for a specific provider",
+      args: {
+        providerId: t.arg.id({ required: true }),
+        technology: t.arg.string({ required: false }),
+        softwareId: t.arg.id({ required: false }),
+      },
+      resolve: async (_device, _args, _ctx) => {
+        // Will implement in next task
+        return [];
+      },
+    }),
+
+    // Global features
+    features: t.field({
+      type: [FeatureType],
+      description: "Features supported by this device (any provider)",
+      args: {
+        softwareId: t.arg.id({ required: false }),
+      },
+      resolve: async (_device, _args, _ctx) => {
+        // Will implement in next task
+        return [];
+      },
+    }),
+
+    // Provider-specific features
+    featuresForProvider: t.field({
+      type: [FeatureType],
+      description: "Features supported by this device for a specific provider",
+      args: {
+        providerId: t.arg.id({ required: true }),
+        softwareId: t.arg.id({ required: false }),
+      },
+      resolve: async (_device, _args, _ctx) => {
+        // Will implement in next task
+        return [];
+      },
+    }),
+  }),
+});

--- a/packages/backend/src/graphql/schema/types/feature.ts
+++ b/packages/backend/src/graphql/schema/types/feature.ts
@@ -51,25 +51,25 @@ FeatureAvailabilityType.implement({
     device: t.field({
       type: DeviceType,
       resolve: async (_availability, _args, _ctx) => {
-        return null as any; // Will implement
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
       },
     }),
     software: t.field({
       type: SoftwareType,
       resolve: async (_availability, _args, _ctx) => {
-        return null as any; // Will implement
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
       },
     }),
     provider: t.field({
       type: ProviderType,
       resolve: async (_availability, _args, _ctx) => {
-        return null as any; // Will implement
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
       },
     }),
     feature: t.field({
       type: FeatureType,
       resolve: async (_availability, _args, _ctx) => {
-        return null as any; // Will implement
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
       },
     }),
   }),

--- a/packages/backend/src/graphql/schema/types/feature.ts
+++ b/packages/backend/src/graphql/schema/types/feature.ts
@@ -1,7 +1,5 @@
 import { builder } from "../builder";
-import { DeviceType } from "./device";
-import { ProviderType } from "./provider";
-import { SoftwareType } from "./software";
+import { DeviceFeatureType } from "./junctions";
 
 // Feature type definition
 export const FeatureType = builder.objectRef<{
@@ -22,54 +20,16 @@ FeatureType.implement({
     createdAt: t.expose("createdAt", { type: "DateTime" }),
     updatedAt: t.expose("updatedAt", { type: "DateTime" }),
 
-    // Relationships
+    // Use junction type instead
     availability: t.field({
-      type: [FeatureAvailabilityType],
+      type: [DeviceFeatureType],
       description: "Where this feature is available",
       args: {
         deviceId: t.arg.id({ required: false }),
         providerId: t.arg.id({ required: false }),
       },
       resolve: async (_feature, _args, _ctx) => {
-        // Will implement with repository
         return [];
-      },
-    }),
-  }),
-});
-
-// Feature availability result type (junction data)
-export const FeatureAvailabilityType = builder.objectRef<{
-  deviceId: number;
-  softwareId: number;
-  providerId: number;
-  featureId: number;
-}>("FeatureAvailability");
-
-FeatureAvailabilityType.implement({
-  fields: (t) => ({
-    device: t.field({
-      type: DeviceType,
-      resolve: async (_availability, _args, _ctx) => {
-        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
-      },
-    }),
-    software: t.field({
-      type: SoftwareType,
-      resolve: async (_availability, _args, _ctx) => {
-        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
-      },
-    }),
-    provider: t.field({
-      type: ProviderType,
-      resolve: async (_availability, _args, _ctx) => {
-        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
-      },
-    }),
-    feature: t.field({
-      type: FeatureType,
-      resolve: async (_availability, _args, _ctx) => {
-        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
       },
     }),
   }),

--- a/packages/backend/src/graphql/schema/types/feature.ts
+++ b/packages/backend/src/graphql/schema/types/feature.ts
@@ -1,0 +1,76 @@
+import { builder } from "../builder";
+import { DeviceType } from "./device";
+import { ProviderType } from "./provider";
+import { SoftwareType } from "./software";
+
+// Feature type definition
+export const FeatureType = builder.objectRef<{
+  id: number;
+  name: string;
+  description: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}>("Feature");
+
+FeatureType.implement({
+  fields: (t) => ({
+    id: t.exposeID("id"),
+    name: t.exposeString("name", {
+      description: 'Feature name (e.g., "VoLTE", "VoWiFi")',
+    }),
+    description: t.exposeString("description", { nullable: true }),
+    createdAt: t.expose("createdAt", { type: "DateTime" }),
+    updatedAt: t.expose("updatedAt", { type: "DateTime" }),
+
+    // Relationships
+    availability: t.field({
+      type: [FeatureAvailabilityType],
+      description: "Where this feature is available",
+      args: {
+        deviceId: t.arg.id({ required: false }),
+        providerId: t.arg.id({ required: false }),
+      },
+      resolve: async (_feature, _args, _ctx) => {
+        // Will implement with repository
+        return [];
+      },
+    }),
+  }),
+});
+
+// Feature availability result type (junction data)
+export const FeatureAvailabilityType = builder.objectRef<{
+  deviceId: number;
+  softwareId: number;
+  providerId: number;
+  featureId: number;
+}>("FeatureAvailability");
+
+FeatureAvailabilityType.implement({
+  fields: (t) => ({
+    device: t.field({
+      type: DeviceType,
+      resolve: async (_availability, _args, _ctx) => {
+        return null as any; // Will implement
+      },
+    }),
+    software: t.field({
+      type: SoftwareType,
+      resolve: async (_availability, _args, _ctx) => {
+        return null as any; // Will implement
+      },
+    }),
+    provider: t.field({
+      type: ProviderType,
+      resolve: async (_availability, _args, _ctx) => {
+        return null as any; // Will implement
+      },
+    }),
+    feature: t.field({
+      type: FeatureType,
+      resolve: async (_availability, _args, _ctx) => {
+        return null as any; // Will implement
+      },
+    }),
+  }),
+});

--- a/packages/backend/src/graphql/schema/types/junctions.ts
+++ b/packages/backend/src/graphql/schema/types/junctions.ts
@@ -1,0 +1,222 @@
+import { builder } from "../builder";
+import { DeviceType } from "./device";
+import { SoftwareType } from "./software";
+import { BandType } from "./band";
+import { ComboType } from "./combo";
+import { FeatureType } from "./feature";
+import { ProviderType } from "./provider";
+
+// ====================
+// DEVICE BAND (Global)
+// ====================
+export const DeviceBandType = builder.objectRef<{
+  deviceId: number;
+  softwareId: number;
+  bandId: number;
+}>("DeviceBand");
+
+DeviceBandType.implement({
+  description: "Global band support for a device/software combination",
+  fields: (t) => ({
+    device: t.field({
+      type: DeviceType,
+      resolve: async (_junction, _args, _ctx) => {
+        // Will implement with DataLoader
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+    software: t.field({
+      type: SoftwareType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+    band: t.field({
+      type: BandType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+  }),
+});
+
+// ==============================
+// DEVICE BAND (Provider-Specific)
+// ==============================
+export const ProviderDeviceBandType = builder.objectRef<{
+  providerId: number;
+  deviceId: number;
+  softwareId: number;
+  bandId: number;
+}>("ProviderDeviceBand");
+
+ProviderDeviceBandType.implement({
+  description:
+    "Provider-specific band support for a device/software combination",
+  fields: (t) => ({
+    provider: t.field({
+      type: ProviderType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+    device: t.field({
+      type: DeviceType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+    software: t.field({
+      type: SoftwareType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+    band: t.field({
+      type: BandType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+  }),
+});
+
+// ====================
+// DEVICE COMBO (Global)
+// ====================
+export const DeviceComboType = builder.objectRef<{
+  deviceId: number;
+  softwareId: number;
+  comboId: number;
+}>("DeviceCombo");
+
+DeviceComboType.implement({
+  description: "Global combo support for a device/software combination",
+  fields: (t) => ({
+    device: t.field({
+      type: DeviceType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+    software: t.field({
+      type: SoftwareType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+    combo: t.field({
+      type: ComboType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+  }),
+});
+
+// ==============================
+// DEVICE COMBO (Provider-Specific)
+// ==============================
+export const ProviderDeviceComboType = builder.objectRef<{
+  providerId: number;
+  deviceId: number;
+  softwareId: number;
+  comboId: number;
+}>("ProviderDeviceCombo");
+
+ProviderDeviceComboType.implement({
+  description:
+    "Provider-specific combo support for a device/software combination",
+  fields: (t) => ({
+    provider: t.field({
+      type: ProviderType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+    device: t.field({
+      type: DeviceType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+    software: t.field({
+      type: SoftwareType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+    combo: t.field({
+      type: ComboType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+  }),
+});
+
+// ====================
+// DEVICE FEATURE
+// ====================
+export const DeviceFeatureType = builder.objectRef<{
+  deviceId: number;
+  softwareId: number;
+  providerId: number;
+  featureId: number;
+}>("DeviceFeature");
+
+DeviceFeatureType.implement({
+  description: "Feature support for a device/software/provider combination",
+  fields: (t) => ({
+    device: t.field({
+      type: DeviceType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+    software: t.field({
+      type: SoftwareType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+    provider: t.field({
+      type: ProviderType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+    feature: t.field({
+      type: FeatureType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+  }),
+});
+
+// ====================
+// COMBO BAND
+// ====================
+export const ComboBandType = builder.objectRef<{
+  comboId: number;
+  bandId: number;
+}>("ComboBand");
+
+ComboBandType.implement({
+  description: "Band component of a combo (with position)",
+  fields: (t) => ({
+    combo: t.field({
+      type: ComboType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+    band: t.field({
+      type: BandType,
+      resolve: async (_junction, _args, _ctx) => {
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
+      },
+    }),
+  }),
+});

--- a/packages/backend/src/graphql/schema/types/provider.ts
+++ b/packages/backend/src/graphql/schema/types/provider.ts
@@ -1,0 +1,22 @@
+import { builder } from "../builder";
+
+// Provider type definition
+export const ProviderType = builder.objectRef<{
+  providerId: number;
+  name: string;
+  country: string;
+  networkType: string;
+}>("Provider");
+
+ProviderType.implement({
+  fields: (t) => ({
+    id: t.exposeID("providerId"),
+    name: t.exposeString("name", {
+      description: 'Provider name (e.g., "Telus", "Rogers")',
+    }),
+    country: t.exposeString("country"),
+    networkType: t.exposeString("networkType", {
+      description: 'Network type (e.g., "5G", "LTE")',
+    }),
+  }),
+});

--- a/packages/backend/src/graphql/schema/types/provider.ts
+++ b/packages/backend/src/graphql/schema/types/provider.ts
@@ -2,7 +2,7 @@ import { builder } from "../builder";
 
 // Provider type definition
 export const ProviderType = builder.objectRef<{
-  providerId: number;
+  id: number;
   name: string;
   country: string;
   networkType: string;
@@ -10,7 +10,7 @@ export const ProviderType = builder.objectRef<{
 
 ProviderType.implement({
   fields: (t) => ({
-    id: t.exposeID("providerId"),
+    id: t.exposeID("id"),
     name: t.exposeString("name", {
       description: 'Provider name (e.g., "Telus", "Rogers")',
     }),

--- a/packages/backend/src/graphql/schema/types/software.ts
+++ b/packages/backend/src/graphql/schema/types/software.ts
@@ -35,7 +35,7 @@ SoftwareType.implement({
       description: "The device this software runs on",
       resolve: async (_software, _args, _ctx) => {
         // Will implement with DataLoader
-        return null as any;
+        return null as any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will implement
       },
     }),
   }),

--- a/packages/backend/src/graphql/schema/types/software.ts
+++ b/packages/backend/src/graphql/schema/types/software.ts
@@ -1,0 +1,42 @@
+import { builder } from "../builder";
+import { DeviceType } from "./device";
+
+// Software type definition
+export const SoftwareType = builder.objectRef<{
+  id: number;
+  name: string;
+  platform: string;
+  ptcrb: number | null;
+  svn: number | null;
+  buildNumber: string | null;
+  releaseDate: string;
+  deviceId: number;
+  createdAt: Date;
+  updatedAt: Date;
+}>("Software");
+
+SoftwareType.implement({
+  fields: (t) => ({
+    id: t.exposeID("id"),
+    name: t.exposeString("name"),
+    platform: t.exposeString("platform", {
+      description: "Operating system platform (iOS, Android, etc.)",
+    }),
+    ptcrb: t.exposeInt("ptcrb", { nullable: true }),
+    svn: t.exposeInt("svn", { nullable: true }),
+    buildNumber: t.exposeString("buildNumber", { nullable: true }),
+    releaseDate: t.expose("releaseDate", { type: "DateTime" }),
+    createdAt: t.expose("createdAt", { type: "DateTime" }),
+    updatedAt: t.expose("updatedAt", { type: "DateTime" }),
+
+    // Relationships
+    device: t.field({
+      type: DeviceType,
+      description: "The device this software runs on",
+      resolve: async (_software, _args, _ctx) => {
+        // Will implement with DataLoader
+        return null as any;
+      },
+    }),
+  }),
+});


### PR DESCRIPTION
## Description
This PR adds all the types for the graphQL implementation.

## Approach Taken
Following the graphQL guides, I constructed the types for all my core models. I needed to create a couple enums since they didn't comply with the graphQL rules. 

## What Could Go Wrong?
Nothing really. Adds the type definitions that align with our database schema and we don't have any users yet, so there isn't a real risk.

## Remediation Strategy 
NA
