### PR TITLE
XMDEV-537: Adds data access (repository) layer for graphQL

### DIFF
--- a/packages/backend/bun.lock
+++ b/packages/backend/bun.lock
@@ -15,6 +15,7 @@
         "zod": "^4.1.13",
       },
       "devDependencies": {
+        "@faker-js/faker": "^10.1.0",
         "@graphql-codegen/cli": "^6.1.0",
         "@graphql-codegen/typescript": "^5.0.6",
         "@types/bun": "latest",
@@ -159,6 +160,8 @@
     "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@faker-js/faker": ["@faker-js/faker@10.1.0", "", {}, "sha512-C3mrr3b5dRVlKPJdfrAXS8+dq+rq8Qm5SNRazca0JKgw1HQERFmrVb0towvMmw5uu8hHKNiQasMaR/tydf3Zsg=="],
 
     "@fastify/busboy": ["@fastify/busboy@3.2.0", "", {}, "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -26,6 +26,7 @@
     "zod": "^4.1.13"
   },
   "devDependencies": {
+    "@faker-js/faker": "^10.1.0",
     "@graphql-codegen/cli": "^6.1.0",
     "@graphql-codegen/typescript": "^5.0.6",
     "@types/bun": "latest",

--- a/packages/backend/src/repositories/band.repository.ts
+++ b/packages/backend/src/repositories/band.repository.ts
@@ -1,4 +1,4 @@
-import { eq, and, inArray, like, sql } from "drizzle-orm";
+import { eq, and, inArray, like } from "drizzle-orm";
 import { db } from "../db/client";
 import {
   band,
@@ -71,8 +71,8 @@ export class BandRepository {
       // Provider-specific query
       const results = await db
         .selectDistinct({
-          device: device,
-          software: software,
+          device,
+          software,
           providerId: providerDeviceSoftwareBand.providerId,
         })
         .from(providerDeviceSoftwareBand)
@@ -115,8 +115,8 @@ export class BandRepository {
       // Global capability query
       const results = await db
         .selectDistinct({
-          device: device,
-          software: software,
+          device,
+          software,
         })
         .from(deviceSoftwareBand)
         .innerJoin(device, eq(deviceSoftwareBand.deviceId, device.id))
@@ -171,7 +171,7 @@ export class BandRepository {
     }
 
     return db
-      .select({ band: band })
+      .select({ band })
       .from(deviceSoftwareBand)
       .innerJoin(band, eq(deviceSoftwareBand.bandId, band.id))
       .where(and(...conditions))
@@ -198,7 +198,7 @@ export class BandRepository {
     }
 
     return db
-      .select({ band: band })
+      .select({ band })
       .from(providerDeviceSoftwareBand)
       .innerJoin(band, eq(providerDeviceSoftwareBand.bandId, band.id))
       .where(and(...conditions))

--- a/packages/backend/src/repositories/band.repository.ts
+++ b/packages/backend/src/repositories/band.repository.ts
@@ -1,0 +1,209 @@
+import { eq, and, inArray, like, sql } from "drizzle-orm";
+import { db } from "../db/client";
+import {
+  band,
+  device,
+  software,
+  deviceSoftwareBand,
+  providerDeviceSoftwareBand,
+} from "../db/schema";
+import type { FindDevicesByBandParams, DeviceCapabilityResult } from "./types";
+
+export class BandRepository {
+  /**
+   * Find band by ID
+   */
+  async findById(id: number) {
+    const result = await db.select().from(band).where(eq(band.id, id)).limit(1);
+
+    return result[0] || null;
+  }
+
+  /**
+   * Find multiple bands by IDs
+   */
+  async findByIds(ids: number[]) {
+    if (ids.length === 0) return [];
+
+    return db.select().from(band).where(inArray(band.id, ids));
+  }
+
+  /**
+   * Search bands by technology and/or band number
+   */
+  async search(filters?: { technology?: string; bandNumber?: string }) {
+    const conditions = [];
+
+    if (filters?.technology) {
+      conditions.push(eq(band.technology, filters.technology));
+    }
+
+    if (filters?.bandNumber) {
+      conditions.push(like(band.bandNumber, `%${filters.bandNumber}%`));
+    }
+
+    let query = db.select().from(band);
+
+    if (conditions.length > 0) {
+      query = query.where(and(...conditions)) as any;
+    }
+
+    return query.orderBy(band.technology, band.bandNumber);
+  }
+
+  /**
+   * Find all bands
+   */
+  async findAll() {
+    return db.select().from(band).orderBy(band.technology, band.bandNumber);
+  }
+
+  /**
+   * Find devices that support a specific band
+   * This is a KEY METHOD for capability queries
+   */
+  async findDevicesSupportingBand(
+    params: FindDevicesByBandParams
+  ): Promise<DeviceCapabilityResult[]> {
+    const { bandId, providerId, technology } = params;
+
+    if (providerId) {
+      // Provider-specific query
+      const results = await db
+        .selectDistinct({
+          device: device,
+          software: software,
+          providerId: providerDeviceSoftwareBand.providerId,
+        })
+        .from(providerDeviceSoftwareBand)
+        .innerJoin(device, eq(providerDeviceSoftwareBand.deviceId, device.id))
+        .innerJoin(
+          software,
+          eq(providerDeviceSoftwareBand.softwareId, software.id)
+        )
+        .innerJoin(band, eq(providerDeviceSoftwareBand.bandId, band.id))
+        .where(
+          and(
+            eq(providerDeviceSoftwareBand.bandId, bandId),
+            eq(providerDeviceSoftwareBand.providerId, providerId),
+            technology ? eq(band.technology, technology) : undefined
+          )
+        )
+        .orderBy(device.vendor, device.modelNum);
+
+      // Group by device
+      const deviceMap = new Map<number, DeviceCapabilityResult>();
+
+      for (const row of results) {
+        if (!deviceMap.has(row.device.id)) {
+          deviceMap.set(row.device.id, {
+            device: row.device,
+            software: [],
+            supportStatus: "provider-specific",
+            provider: { providerId: row.providerId }, // Will be populated by DataLoader
+          });
+        }
+
+        const entry = deviceMap.get(row.device.id)!;
+        if (!entry.software.find((s) => s.id === row.software.id)) {
+          entry.software.push(row.software);
+        }
+      }
+
+      return Array.from(deviceMap.values());
+    } else {
+      // Global capability query
+      const results = await db
+        .selectDistinct({
+          device: device,
+          software: software,
+        })
+        .from(deviceSoftwareBand)
+        .innerJoin(device, eq(deviceSoftwareBand.deviceId, device.id))
+        .innerJoin(software, eq(deviceSoftwareBand.softwareId, software.id))
+        .innerJoin(band, eq(deviceSoftwareBand.bandId, band.id))
+        .where(
+          and(
+            eq(deviceSoftwareBand.bandId, bandId),
+            technology ? eq(band.technology, technology) : undefined
+          )
+        )
+        .orderBy(device.vendor, device.modelNum);
+
+      // Group by device
+      const deviceMap = new Map<number, DeviceCapabilityResult>();
+
+      for (const row of results) {
+        if (!deviceMap.has(row.device.id)) {
+          deviceMap.set(row.device.id, {
+            device: row.device,
+            software: [],
+            supportStatus: "global",
+            provider: null,
+          });
+        }
+
+        const entry = deviceMap.get(row.device.id)!;
+        if (!entry.software.find((s) => s.id === row.software.id)) {
+          entry.software.push(row.software);
+        }
+      }
+
+      return Array.from(deviceMap.values());
+    }
+  }
+
+  /**
+   * Find bands for a specific device/software (global)
+   */
+  async findByDeviceSoftware(
+    deviceId: number,
+    softwareId: number,
+    technology?: string
+  ) {
+    const conditions = [
+      eq(deviceSoftwareBand.deviceId, deviceId),
+      eq(deviceSoftwareBand.softwareId, softwareId),
+    ];
+
+    if (technology) {
+      conditions.push(eq(band.technology, technology));
+    }
+
+    return db
+      .select({ band: band })
+      .from(deviceSoftwareBand)
+      .innerJoin(band, eq(deviceSoftwareBand.bandId, band.id))
+      .where(and(...conditions))
+      .then((results) => results.map((r) => r.band));
+  }
+
+  /**
+   * Find bands for a specific device/software/provider
+   */
+  async findByDeviceSoftwareProvider(
+    deviceId: number,
+    softwareId: number,
+    providerId: number,
+    technology?: string
+  ) {
+    const conditions = [
+      eq(providerDeviceSoftwareBand.deviceId, deviceId),
+      eq(providerDeviceSoftwareBand.softwareId, softwareId),
+      eq(providerDeviceSoftwareBand.providerId, providerId),
+    ];
+
+    if (technology) {
+      conditions.push(eq(band.technology, technology));
+    }
+
+    return db
+      .select({ band: band })
+      .from(providerDeviceSoftwareBand)
+      .innerJoin(band, eq(providerDeviceSoftwareBand.bandId, band.id))
+      .where(and(...conditions))
+      .then((results) => results.map((r) => r.band));
+  }
+}
+
+export const bandRepository = new BandRepository();

--- a/packages/backend/src/repositories/band.repository.ts
+++ b/packages/backend/src/repositories/band.repository.ts
@@ -45,7 +45,7 @@ export class BandRepository {
     let query = db.select().from(band);
 
     if (conditions.length > 0) {
-      query = query.where(and(...conditions)) as any;
+      query = query.where(and(...conditions)) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
     }
 
     return query.orderBy(band.technology, band.bandNumber);

--- a/packages/backend/src/repositories/combo.repository.ts
+++ b/packages/backend/src/repositories/combo.repository.ts
@@ -1,0 +1,251 @@
+import { eq, and, inArray, like } from "drizzle-orm";
+import { db } from "../db/client";
+import {
+  combo,
+  comboBand,
+  band,
+  device,
+  software,
+  deviceSoftwareCombo,
+  providerDeviceSoftwareCombo,
+} from "../db/schema";
+import type { FindDevicesByComboParams, DeviceCapabilityResult } from "./types";
+
+export class ComboRepository {
+  /**
+   * Find combo by ID
+   */
+  async findById(id: number) {
+    const result = await db
+      .select()
+      .from(combo)
+      .where(eq(combo.comboId, id))
+      .limit(1);
+
+    return result[0] || null;
+  }
+
+  /**
+   * Find multiple combos by IDs
+   */
+  async findByIds(ids: number[]) {
+    if (ids.length === 0) return [];
+
+    return db.select().from(combo).where(inArray(combo.comboId, ids));
+  }
+
+  /**
+   * Search combos
+   */
+  async search(filters?: { technology?: string; name?: string }) {
+    const conditions = [];
+
+    if (filters?.technology) {
+      conditions.push(eq(combo.technology, filters.technology));
+    }
+
+    if (filters?.name) {
+      conditions.push(like(combo.name, `%${filters.name}%`));
+    }
+
+    let query = db.select().from(combo);
+
+    if (conditions.length > 0) {
+      query = query.where(and(...conditions)) as any;
+    }
+
+    return query.orderBy(combo.technology, combo.name);
+  }
+
+  /**
+   * Find all combos
+   */
+  async findAll() {
+    return db.select().from(combo).orderBy(combo.technology, combo.name);
+  }
+
+  /**
+   * Find bands that make up a combo (with position)
+   */
+  async findBandsByCombo(comboId: number) {
+    return db
+      .select({
+        band: band,
+        position: comboBand.position,
+      })
+      .from(comboBand)
+      .innerJoin(band, eq(comboBand.bandId, band.bandId))
+      .where(eq(comboBand.comboId, comboId))
+      .orderBy(comboBand.position);
+  }
+
+  /**
+   * Find bands for multiple combos (for batching)
+   */
+  async findBandsByCombos(comboIds: number[]) {
+    if (comboIds.length === 0) return [];
+
+    return db
+      .select({
+        comboId: comboBand.comboId,
+        band: band,
+        position: comboBand.position,
+      })
+      .from(comboBand)
+      .innerJoin(band, eq(comboBand.bandId, band.bandId))
+      .where(inArray(comboBand.comboId, comboIds))
+      .orderBy(comboBand.comboId, comboBand.position);
+  }
+
+  /**
+   * Find devices that support a specific combo
+   * KEY METHOD for capability queries
+   */
+  async findDevicesSupportingCombo(
+    params: FindDevicesByComboParams
+  ): Promise<DeviceCapabilityResult[]> {
+    const { comboId, providerId, technology } = params;
+
+    if (providerId) {
+      // Provider-specific query
+      const results = await db
+        .selectDistinct({
+          device: device,
+          software: software,
+          providerId: providerDeviceSoftwareCombo.providerId,
+        })
+        .from(providerDeviceSoftwareCombo)
+        .innerJoin(device, eq(providerDeviceSoftwareCombo.deviceId, device.id))
+        .innerJoin(
+          software,
+          eq(providerDeviceSoftwareCombo.softwareId, software.id)
+        )
+        .innerJoin(
+          combo,
+          eq(providerDeviceSoftwareCombo.comboId, combo.comboId)
+        )
+        .where(
+          and(
+            eq(providerDeviceSoftwareCombo.comboId, comboId),
+            eq(providerDeviceSoftwareCombo.providerId, providerId),
+            technology ? eq(combo.technology, technology) : undefined
+          )
+        )
+        .orderBy(device.vendor, device.modelNum);
+
+      // Group by device
+      const deviceMap = new Map<number, DeviceCapabilityResult>();
+
+      for (const row of results) {
+        if (!deviceMap.has(row.device.id)) {
+          deviceMap.set(row.device.id, {
+            device: row.device,
+            software: [],
+            supportStatus: "provider-specific",
+            provider: { providerId: row.providerId },
+          });
+        }
+
+        const entry = deviceMap.get(row.device.id)!;
+        if (!entry.software.find((s) => s.id === row.software.id)) {
+          entry.software.push(row.software);
+        }
+      }
+
+      return Array.from(deviceMap.values());
+    } else {
+      // Global capability query
+      const results = await db
+        .selectDistinct({
+          device: device,
+          software: software,
+        })
+        .from(deviceSoftwareCombo)
+        .innerJoin(device, eq(deviceSoftwareCombo.deviceId, device.id))
+        .innerJoin(software, eq(deviceSoftwareCombo.softwareId, software.id))
+        .innerJoin(combo, eq(deviceSoftwareCombo.comboId, combo.comboId))
+        .where(
+          and(
+            eq(deviceSoftwareCombo.comboId, comboId),
+            technology ? eq(combo.technology, technology) : undefined
+          )
+        )
+        .orderBy(device.vendor, device.modelNum);
+
+      // Group by device
+      const deviceMap = new Map<number, DeviceCapabilityResult>();
+
+      for (const row of results) {
+        if (!deviceMap.has(row.device.id)) {
+          deviceMap.set(row.device.id, {
+            device: row.device,
+            software: [],
+            supportStatus: "global",
+            provider: null,
+          });
+        }
+
+        const entry = deviceMap.get(row.device.id)!;
+        if (!entry.software.find((s) => s.id === row.software.id)) {
+          entry.software.push(row.software);
+        }
+      }
+
+      return Array.from(deviceMap.values());
+    }
+  }
+
+  /**
+   * Find combos for a specific device/software (global)
+   */
+  async findByDeviceSoftware(
+    deviceId: number,
+    softwareId: number,
+    technology?: string
+  ) {
+    const conditions = [
+      eq(deviceSoftwareCombo.deviceId, deviceId),
+      eq(deviceSoftwareCombo.softwareId, softwareId),
+    ];
+
+    if (technology) {
+      conditions.push(eq(combo.technology, technology));
+    }
+
+    return db
+      .select({ combo: combo })
+      .from(deviceSoftwareCombo)
+      .innerJoin(combo, eq(deviceSoftwareCombo.comboId, combo.comboId))
+      .where(and(...conditions))
+      .then((results) => results.map((r) => r.combo));
+  }
+
+  /**
+   * Find combos for a specific device/software/provider
+   */
+  async findByDeviceSoftwareProvider(
+    deviceId: number,
+    softwareId: number,
+    providerId: number,
+    technology?: string
+  ) {
+    const conditions = [
+      eq(providerDeviceSoftwareCombo.deviceId, deviceId),
+      eq(providerDeviceSoftwareCombo.softwareId, softwareId),
+      eq(providerDeviceSoftwareCombo.providerId, providerId),
+    ];
+
+    if (technology) {
+      conditions.push(eq(combo.technology, technology));
+    }
+
+    return db
+      .select({ combo: combo })
+      .from(providerDeviceSoftwareCombo)
+      .innerJoin(combo, eq(providerDeviceSoftwareCombo.comboId, combo.comboId))
+      .where(and(...conditions))
+      .then((results) => results.map((r) => r.combo));
+  }
+}
+
+export const comboRepository = new ComboRepository();

--- a/packages/backend/src/repositories/combo.repository.ts
+++ b/packages/backend/src/repositories/combo.repository.ts
@@ -19,7 +19,7 @@ export class ComboRepository {
     const result = await db
       .select()
       .from(combo)
-      .where(eq(combo.comboId, id))
+      .where(eq(combo.id, id))
       .limit(1);
 
     return result[0] || null;
@@ -31,7 +31,7 @@ export class ComboRepository {
   async findByIds(ids: number[]) {
     if (ids.length === 0) return [];
 
-    return db.select().from(combo).where(inArray(combo.comboId, ids));
+    return db.select().from(combo).where(inArray(combo.id, ids));
   }
 
   /**
@@ -65,18 +65,16 @@ export class ComboRepository {
   }
 
   /**
-   * Find bands that make up a combo (with position)
+   * Find bands that make up a combo
    */
   async findBandsByCombo(comboId: number) {
     return db
       .select({
-        band: band,
-        position: comboBand.position,
+        band,
       })
       .from(comboBand)
-      .innerJoin(band, eq(comboBand.bandId, band.bandId))
-      .where(eq(comboBand.comboId, comboId))
-      .orderBy(comboBand.position);
+      .innerJoin(band, eq(comboBand.bandId, band.id))
+      .where(eq(comboBand.comboId, comboId));
   }
 
   /**
@@ -88,13 +86,12 @@ export class ComboRepository {
     return db
       .select({
         comboId: comboBand.comboId,
-        band: band,
-        position: comboBand.position,
+        band,
       })
       .from(comboBand)
-      .innerJoin(band, eq(comboBand.bandId, band.bandId))
+      .innerJoin(band, eq(comboBand.bandId, band.id))
       .where(inArray(comboBand.comboId, comboIds))
-      .orderBy(comboBand.comboId, comboBand.position);
+      .orderBy(comboBand.comboId);
   }
 
   /**
@@ -110,8 +107,8 @@ export class ComboRepository {
       // Provider-specific query
       const results = await db
         .selectDistinct({
-          device: device,
-          software: software,
+          device,
+          software,
           providerId: providerDeviceSoftwareCombo.providerId,
         })
         .from(providerDeviceSoftwareCombo)
@@ -120,10 +117,7 @@ export class ComboRepository {
           software,
           eq(providerDeviceSoftwareCombo.softwareId, software.id)
         )
-        .innerJoin(
-          combo,
-          eq(providerDeviceSoftwareCombo.comboId, combo.comboId)
-        )
+        .innerJoin(combo, eq(providerDeviceSoftwareCombo.comboId, combo.id))
         .where(
           and(
             eq(providerDeviceSoftwareCombo.comboId, comboId),
@@ -157,13 +151,13 @@ export class ComboRepository {
       // Global capability query
       const results = await db
         .selectDistinct({
-          device: device,
-          software: software,
+          device,
+          software,
         })
         .from(deviceSoftwareCombo)
         .innerJoin(device, eq(deviceSoftwareCombo.deviceId, device.id))
         .innerJoin(software, eq(deviceSoftwareCombo.softwareId, software.id))
-        .innerJoin(combo, eq(deviceSoftwareCombo.comboId, combo.comboId))
+        .innerJoin(combo, eq(deviceSoftwareCombo.comboId, combo.id))
         .where(
           and(
             eq(deviceSoftwareCombo.comboId, comboId),
@@ -213,9 +207,9 @@ export class ComboRepository {
     }
 
     return db
-      .select({ combo: combo })
+      .select({ combo })
       .from(deviceSoftwareCombo)
-      .innerJoin(combo, eq(deviceSoftwareCombo.comboId, combo.comboId))
+      .innerJoin(combo, eq(deviceSoftwareCombo.comboId, combo.id))
       .where(and(...conditions))
       .then((results) => results.map((r) => r.combo));
   }
@@ -240,9 +234,9 @@ export class ComboRepository {
     }
 
     return db
-      .select({ combo: combo })
+      .select({ combo })
       .from(providerDeviceSoftwareCombo)
-      .innerJoin(combo, eq(providerDeviceSoftwareCombo.comboId, combo.comboId))
+      .innerJoin(combo, eq(providerDeviceSoftwareCombo.comboId, combo.id))
       .where(and(...conditions))
       .then((results) => results.map((r) => r.combo));
   }

--- a/packages/backend/src/repositories/combo.repository.ts
+++ b/packages/backend/src/repositories/combo.repository.ts
@@ -51,7 +51,7 @@ export class ComboRepository {
     let query = db.select().from(combo);
 
     if (conditions.length > 0) {
-      query = query.where(and(...conditions)) as any;
+      query = query.where(and(...conditions)) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
     }
 
     return query.orderBy(combo.technology, combo.name);

--- a/packages/backend/src/repositories/device.repository.ts
+++ b/packages/backend/src/repositories/device.repository.ts
@@ -66,7 +66,7 @@ export class DeviceRepository {
     }
 
     if (conditions.length > 0) {
-      query = query.where(and(...conditions)) as any;
+      query = query.where(and(...conditions)) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
     }
 
     return query.limit(limit).offset(offset).orderBy(device.releaseDate);

--- a/packages/backend/src/repositories/device.repository.ts
+++ b/packages/backend/src/repositories/device.repository.ts
@@ -1,6 +1,6 @@
 import { eq, and, like, gte, lte, sql, inArray } from "drizzle-orm";
 import { db } from "../db/client";
-import { device, software } from "../db/schema";
+import { device } from "../db/schema";
 import type { SearchDevicesParams } from "./types";
 
 export class DeviceRepository {

--- a/packages/backend/src/repositories/device.repository.ts
+++ b/packages/backend/src/repositories/device.repository.ts
@@ -1,0 +1,94 @@
+import { eq, and, like, gte, lte, sql, inArray } from "drizzle-orm";
+import { db } from "../db/client";
+import { device, software } from "../db/schema";
+import type { SearchDevicesParams } from "./types";
+
+export class DeviceRepository {
+  /**
+   * Find device by ID
+   */
+  async findById(id: number) {
+    const result = await db
+      .select()
+      .from(device)
+      .where(eq(device.id, id))
+      .limit(1);
+
+    return result[0] || null;
+  }
+
+  /**
+   * Find multiple devices by IDs
+   */
+  async findByIds(ids: number[]) {
+    if (ids.length === 0) return [];
+
+    return db.select().from(device).where(inArray(device.id, ids));
+  }
+
+  /**
+   * Search devices with filters
+   */
+  async search(params: SearchDevicesParams) {
+    const {
+      vendor,
+      modelNum,
+      marketName,
+      releasedAfter,
+      releasedBefore,
+      limit = 50,
+      offset = 0,
+    } = params;
+
+    let query = db.select().from(device);
+
+    // Build WHERE conditions
+    const conditions = [];
+
+    if (vendor) {
+      conditions.push(like(device.vendor, `%${vendor}%`));
+    }
+
+    if (modelNum) {
+      conditions.push(like(device.modelNum, `%${modelNum}%`));
+    }
+
+    if (marketName) {
+      conditions.push(like(device.marketName, `%${marketName}%`));
+    }
+
+    if (releasedAfter) {
+      conditions.push(gte(device.releaseDate, releasedAfter));
+    }
+
+    if (releasedBefore) {
+      conditions.push(lte(device.releaseDate, releasedBefore));
+    }
+
+    if (conditions.length > 0) {
+      query = query.where(and(...conditions)) as any;
+    }
+
+    return query.limit(limit).offset(offset).orderBy(device.releaseDate);
+  }
+
+  /**
+   * Get all devices (for seeding/testing)
+   */
+  async findAll() {
+    return db.select().from(device).orderBy(device.vendor, device.modelNum);
+  }
+
+  /**
+   * Count total devices
+   */
+  async count() {
+    const result = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(device);
+
+    return Number(result[0].count);
+  }
+}
+
+export const deviceRepository = new DeviceRepository();

--- a/packages/backend/src/repositories/feature.repository.ts
+++ b/packages/backend/src/repositories/feature.repository.ts
@@ -41,7 +41,7 @@ export class FeatureRepository {
     let query = db.select().from(feature);
 
     if (filters?.name) {
-      query = query.where(like(feature.name, `%${filters.name}%`)) as any;
+      query = query.where(like(feature.name, `%${filters.name}%`)) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
     }
 
     return query.orderBy(feature.name);

--- a/packages/backend/src/repositories/feature.repository.ts
+++ b/packages/backend/src/repositories/feature.repository.ts
@@ -1,0 +1,139 @@
+import { eq, and, inArray, like } from "drizzle-orm";
+import { db } from "../db/client";
+import {
+  feature,
+  device,
+  software,
+  provider,
+  deviceSoftwareProviderFeature,
+} from "../db/schema";
+import type {
+  FindDevicesByFeatureParams,
+  DeviceCapabilityResult,
+} from "./types";
+
+export class FeatureRepository {
+  /**
+   * Find feature by ID
+   */
+  async findById(id: number) {
+    const result = await db
+      .select()
+      .from(feature)
+      .where(eq(feature.id, id))
+      .limit(1);
+
+    return result[0] || null;
+  }
+
+  /**
+   * Find multiple features by IDs
+   */
+  async findByIds(ids: number[]) {
+    if (ids.length === 0) return [];
+
+    return db.select().from(feature).where(inArray(feature.id, ids));
+  }
+
+  /**
+   * Search features by name
+   */
+  async search(filters?: { name?: string }) {
+    let query = db.select().from(feature);
+
+    if (filters?.name) {
+      query = query.where(like(feature.name, `%${filters.name}%`)) as any;
+    }
+
+    return query.orderBy(feature.name);
+  }
+
+  /**
+   * Find all features
+   */
+  async findAll() {
+    return db.select().from(feature).orderBy(feature.name);
+  }
+
+  /**
+   * Find devices that support a specific feature
+   * KEY METHOD for capability queries
+   */
+  async findDevicesSupportingFeature(
+    params: FindDevicesByFeatureParams
+  ): Promise<DeviceCapabilityResult[]> {
+    const { featureId, providerId } = params;
+
+    const conditions = [eq(deviceSoftwareProviderFeature.featureId, featureId)];
+
+    if (providerId) {
+      conditions.push(eq(deviceSoftwareProviderFeature.providerId, providerId));
+    }
+
+    const results = await db
+      .selectDistinct({
+        device: device,
+        software: software,
+        providerId: deviceSoftwareProviderFeature.providerId,
+      })
+      .from(deviceSoftwareProviderFeature)
+      .innerJoin(device, eq(deviceSoftwareProviderFeature.deviceId, device.id))
+      .innerJoin(
+        software,
+        eq(deviceSoftwareProviderFeature.softwareId, software.id)
+      )
+      .where(and(...conditions))
+      .orderBy(device.vendor, device.modelNum);
+
+    // Group by device
+    const deviceMap = new Map<number, DeviceCapabilityResult>();
+
+    for (const row of results) {
+      if (!deviceMap.has(row.device.id)) {
+        deviceMap.set(row.device.id, {
+          device: row.device,
+          software: [],
+          supportStatus: providerId ? "provider-specific" : "global",
+          provider: providerId ? { providerId: row.providerId } : null,
+        });
+      }
+
+      const entry = deviceMap.get(row.device.id)!;
+      if (!entry.software.find((s) => s.id === row.software.id)) {
+        entry.software.push(row.software);
+      }
+    }
+
+    return Array.from(deviceMap.values());
+  }
+
+  /**
+   * Find features for a specific device/software/provider
+   */
+  async findByDeviceSoftwareProvider(
+    deviceId: number,
+    softwareId: number,
+    providerId?: number
+  ) {
+    const conditions = [
+      eq(deviceSoftwareProviderFeature.deviceId, deviceId),
+      eq(deviceSoftwareProviderFeature.softwareId, softwareId),
+    ];
+
+    if (providerId) {
+      conditions.push(eq(deviceSoftwareProviderFeature.providerId, providerId));
+    }
+
+    return db
+      .selectDistinct({ feature: feature })
+      .from(deviceSoftwareProviderFeature)
+      .innerJoin(
+        feature,
+        eq(deviceSoftwareProviderFeature.featureId, feature.id)
+      )
+      .where(and(...conditions))
+      .then((results) => results.map((r) => r.feature));
+  }
+}
+
+export const featureRepository = new FeatureRepository();

--- a/packages/backend/src/repositories/feature.repository.ts
+++ b/packages/backend/src/repositories/feature.repository.ts
@@ -4,7 +4,6 @@ import {
   feature,
   device,
   software,
-  provider,
   deviceSoftwareProviderFeature,
 } from "../db/schema";
 import type {
@@ -72,8 +71,8 @@ export class FeatureRepository {
 
     const results = await db
       .selectDistinct({
-        device: device,
-        software: software,
+        device,
+        software,
         providerId: deviceSoftwareProviderFeature.providerId,
       })
       .from(deviceSoftwareProviderFeature)
@@ -125,7 +124,7 @@ export class FeatureRepository {
     }
 
     return db
-      .selectDistinct({ feature: feature })
+      .selectDistinct({ feature })
       .from(deviceSoftwareProviderFeature)
       .innerJoin(
         feature,

--- a/packages/backend/src/repositories/index.ts
+++ b/packages/backend/src/repositories/index.ts
@@ -1,0 +1,7 @@
+export * from "./device.repository";
+export * from "./software.repository";
+export * from "./band.repository";
+export * from "./combo.repository";
+export * from "./feature.repository";
+export * from "./provider.repository";
+export * from "./types";

--- a/packages/backend/src/repositories/provider.repository.ts
+++ b/packages/backend/src/repositories/provider.repository.ts
@@ -10,7 +10,7 @@ export class ProviderRepository {
     const result = await db
       .select()
       .from(provider)
-      .where(eq(provider.providerId, id))
+      .where(eq(provider.id, id))
       .limit(1);
 
     return result[0] || null;
@@ -22,7 +22,7 @@ export class ProviderRepository {
   async findByIds(ids: number[]) {
     if (ids.length === 0) return [];
 
-    return db.select().from(provider).where(inArray(provider.providerId, ids));
+    return db.select().from(provider).where(inArray(provider.id, ids));
   }
 
   /**

--- a/packages/backend/src/repositories/provider.repository.ts
+++ b/packages/backend/src/repositories/provider.repository.ts
@@ -1,0 +1,36 @@
+import { eq, inArray } from "drizzle-orm";
+import { db } from "../db/client";
+import { provider } from "../db/schema";
+
+export class ProviderRepository {
+  /**
+   * Find provider by ID
+   */
+  async findById(id: number) {
+    const result = await db
+      .select()
+      .from(provider)
+      .where(eq(provider.providerId, id))
+      .limit(1);
+
+    return result[0] || null;
+  }
+
+  /**
+   * Find multiple providers by IDs
+   */
+  async findByIds(ids: number[]) {
+    if (ids.length === 0) return [];
+
+    return db.select().from(provider).where(inArray(provider.providerId, ids));
+  }
+
+  /**
+   * Find all providers
+   */
+  async findAll() {
+    return db.select().from(provider).orderBy(provider.name);
+  }
+}
+
+export const providerRepository = new ProviderRepository();

--- a/packages/backend/src/repositories/software.repository.ts
+++ b/packages/backend/src/repositories/software.repository.ts
@@ -1,0 +1,69 @@
+import { eq, and, inArray, gte } from "drizzle-orm";
+import { db } from "../db/client";
+import { software } from "../db/schema";
+
+export class SoftwareRepository {
+  /**
+   * Find software by ID
+   */
+  async findById(id: number) {
+    const result = await db
+      .select()
+      .from(software)
+      .where(eq(software.id, id))
+      .limit(1);
+
+    return result[0] || null;
+  }
+
+  /**
+   * Find multiple software by IDs
+   */
+  async findByIds(ids: number[]) {
+    if (ids.length === 0) return [];
+
+    return db.select().from(software).where(inArray(software.id, ids));
+  }
+
+  /**
+   * Find all software for a device
+   */
+  async findByDevice(
+    deviceId: number,
+    filters?: {
+      platform?: string;
+      releasedAfter?: string;
+    }
+  ) {
+    const conditions = [eq(software.deviceId, deviceId)];
+
+    if (filters?.platform) {
+      conditions.push(eq(software.platform, filters.platform));
+    }
+
+    if (filters?.releasedAfter) {
+      conditions.push(gte(software.releaseDate, filters.releasedAfter));
+    }
+
+    return db
+      .select()
+      .from(software)
+      .where(and(...conditions))
+      .orderBy(software.releaseDate);
+  }
+
+  /**
+   * Find software for multiple devices (for batching)
+   */
+  async findByDevices(deviceIds: number[]) {
+    if (deviceIds.length === 0) return [];
+
+    return db
+      .select()
+      .from(software)
+      .where(inArray(software.deviceId, deviceIds))
+      .orderBy(software.deviceId, software.releaseDate);
+  }
+}
+
+export const softwareRepository = new SoftwareRepository();

--- a/packages/backend/src/repositories/test-repositories.ts
+++ b/packages/backend/src/repositories/test-repositories.ts
@@ -33,7 +33,7 @@ async function testRepositories() {
   console.log(`   Found ${bands.length} NR bands`);
   if (bands.length > 0) {
     const bandDevices = await bandRepository.findDevicesSupportingBand({
-      bandId: bands[0].bandId,
+      bandId: bands[0].id,
     });
     console.log(
       `   Band ${bands[0].bandNumber}: supported by ${bandDevices.length} devices globally`
@@ -45,8 +45,8 @@ async function testRepositories() {
   const providers = await providerRepository.findAll();
   if (bands.length > 0 && providers.length > 0) {
     const providerBandDevices = await bandRepository.findDevicesSupportingBand({
-      bandId: bands[0].bandId,
-      providerId: providers[0].providerId,
+      bandId: bands[0].id,
+      providerId: providers[0].id,
     });
     console.log(
       `   Band ${bands[0].bandNumber} on ${providers[0].name}: supported by ${providerBandDevices.length} devices`
@@ -65,7 +65,7 @@ async function testRepositories() {
   console.log(`   Found ${combos.length} EN-DC combos`);
   if (combos.length > 0) {
     const comboDevices = await comboRepository.findDevicesSupportingCombo({
-      comboId: combos[0].comboId,
+      comboId: combos[0].id,
     });
     console.log(
       `   Combo ${combos[0].name}: supported by ${comboDevices.length} devices`

--- a/packages/backend/src/repositories/test-repositories.ts
+++ b/packages/backend/src/repositories/test-repositories.ts
@@ -1,0 +1,105 @@
+import {
+  deviceRepository,
+  softwareRepository,
+  bandRepository,
+  comboRepository,
+  featureRepository,
+  providerRepository,
+} from "./index";
+
+async function testRepositories() {
+  console.log("🧪 Testing Repositories\n");
+
+  // Test 1: Device Repository
+  console.log("1. Testing Device Repository...");
+  const devices = await deviceRepository.search({ vendor: "Apple" });
+  console.log(`   Found ${devices.length} Apple devices`);
+  if (devices.length > 0) {
+    console.log(`   First device: ${devices[0].vendor} ${devices[0].modelNum}`);
+  }
+
+  // Test 2: Software Repository
+  console.log("\n2. Testing Software Repository...");
+  if (devices.length > 0) {
+    const deviceSoftware = await softwareRepository.findByDevice(devices[0].id);
+    console.log(
+      `   Found ${deviceSoftware.length} software versions for ${devices[0].marketName}`
+    );
+  }
+
+  // Test 3: Band Repository - Global
+  console.log("\n3. Testing Band Repository (Global)...");
+  const bands = await bandRepository.search({ technology: "NR" });
+  console.log(`   Found ${bands.length} NR bands`);
+  if (bands.length > 0) {
+    const bandDevices = await bandRepository.findDevicesSupportingBand({
+      bandId: bands[0].bandId,
+    });
+    console.log(
+      `   Band ${bands[0].bandNumber}: supported by ${bandDevices.length} devices globally`
+    );
+  }
+
+  // Test 4: Band Repository - Provider-Specific
+  console.log("\n4. Testing Band Repository (Provider-Specific)...");
+  const providers = await providerRepository.findAll();
+  if (bands.length > 0 && providers.length > 0) {
+    const providerBandDevices = await bandRepository.findDevicesSupportingBand({
+      bandId: bands[0].bandId,
+      providerId: providers[0].providerId,
+    });
+    console.log(
+      `   Band ${bands[0].bandNumber} on ${providers[0].name}: supported by ${providerBandDevices.length} devices`
+    );
+    if (providerBandDevices.length > 0) {
+      console.log(
+        `   First device: ${providerBandDevices[0].device.vendor} ${providerBandDevices[0].device.modelNum}`
+      );
+      console.log(`   Support status: ${providerBandDevices[0].supportStatus}`);
+    }
+  }
+
+  // Test 5: Combo Repository
+  console.log("\n5. Testing Combo Repository...");
+  const combos = await comboRepository.search({ technology: "EN-DC" });
+  console.log(`   Found ${combos.length} EN-DC combos`);
+  if (combos.length > 0) {
+    const comboDevices = await comboRepository.findDevicesSupportingCombo({
+      comboId: combos[0].comboId,
+    });
+    console.log(
+      `   Combo ${combos[0].name}: supported by ${comboDevices.length} devices`
+    );
+  }
+
+  // Test 6: Feature Repository
+  console.log("\n6. Testing Feature Repository...");
+  const features = await featureRepository.findAll();
+  console.log(`   Found ${features.length} features`);
+  if (features.length > 0) {
+    const featureDevices = await featureRepository.findDevicesSupportingFeature(
+      {
+        featureId: features[0].id,
+      }
+    );
+    console.log(
+      `   Feature "${features[0].name}": supported by ${featureDevices.length} devices`
+    );
+  }
+
+  // Test 7: Provider Repository
+  console.log("\n7. Testing Provider Repository...");
+  console.log(`   Found ${providers.length} providers`);
+  providers.forEach((p) => {
+    console.log(`   - ${p.name} (${p.country})`);
+  });
+
+  console.log("\n✅ All repository tests completed!");
+}
+
+testRepositories()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error("❌ Test failed:", error);
+    process.exit(1);
+  });

--- a/packages/backend/src/repositories/types.ts
+++ b/packages/backend/src/repositories/types.ts
@@ -1,0 +1,38 @@
+// Common repository types and interfaces
+
+export interface PaginationParams {
+  limit?: number;
+  offset?: number;
+}
+
+export interface SearchDevicesParams extends PaginationParams {
+  vendor?: string;
+  modelNum?: string;
+  marketName?: string;
+  releasedAfter?: string;
+  releasedBefore?: string;
+}
+
+export interface FindDevicesByBandParams {
+  bandId: number;
+  providerId?: number;
+  technology?: string;
+}
+
+export interface FindDevicesByComboParams {
+  comboId: number;
+  providerId?: number;
+  technology?: string;
+}
+
+export interface FindDevicesByFeatureParams {
+  featureId: number;
+  providerId?: number;
+}
+
+export interface DeviceCapabilityResult {
+  device: any; // Will be typed from Drizzle schema
+  software: any[];
+  supportStatus: "global" | "provider-specific";
+  provider: any | null;
+}

--- a/packages/backend/src/repositories/types.ts
+++ b/packages/backend/src/repositories/types.ts
@@ -31,8 +31,8 @@ export interface FindDevicesByFeatureParams {
 }
 
 export interface DeviceCapabilityResult {
-  device: any; // Will be typed from Drizzle schema
-  software: any[];
+  device: any; // eslint-disable-line @typescript-eslint/no-explicit-any -- Will be typed from Drizzle schema
+  software: any[]; // eslint-disable-line @typescript-eslint/no-explicit-any
   supportStatus: "global" | "provider-specific";
-  provider: any | null;
+  provider: any | null; // eslint-disable-line @typescript-eslint/no-explicit-any
 }

--- a/packages/backend/tests/factories/band.factory.ts
+++ b/packages/backend/tests/factories/band.factory.ts
@@ -62,8 +62,8 @@ export class BandFactory {
       id: this.idCounter++,
       technology,
       bandNumber,
-      createdAt: new Date(),
-      updatedAt: new Date(),
+      dlBandClass: "A",
+      ulBandClass: "A",
       ...overrides,
     };
   }

--- a/packages/backend/tests/factories/band.factory.ts
+++ b/packages/backend/tests/factories/band.factory.ts
@@ -1,0 +1,128 @@
+import { faker } from "@faker-js/faker";
+import type { band } from "../../src/db/schema";
+
+type Band = typeof band.$inferSelect;
+
+export class BandFactory {
+  private static idCounter = 1;
+
+  private static technologies = ["LTE", "5G NR", "UMTS", "GSM"];
+
+  private static bandNumbersByTech: Record<string, string[]> = {
+    LTE: [
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "7",
+      "8",
+      "12",
+      "13",
+      "17",
+      "20",
+      "25",
+      "26",
+      "28",
+      "66",
+      "71",
+    ],
+    "5G NR": [
+      "n1",
+      "n2",
+      "n3",
+      "n5",
+      "n7",
+      "n8",
+      "n12",
+      "n20",
+      "n25",
+      "n28",
+      "n66",
+      "n71",
+      "n77",
+      "n78",
+      "n79",
+    ],
+    UMTS: ["1", "2", "4", "5", "8"],
+    GSM: ["850", "900", "1800", "1900"],
+  };
+
+  /**
+   * Create a band with default or overridden properties
+   */
+  static create(overrides: Partial<Band> = {}): Band {
+    const technology =
+      overrides.technology || faker.helpers.arrayElement(this.technologies);
+    const bandNumber =
+      overrides.bandNumber ||
+      faker.helpers.arrayElement(this.bandNumbersByTech[technology] || ["1"]);
+
+    return {
+      id: this.idCounter++,
+      technology,
+      bandNumber,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...overrides,
+    };
+  }
+
+  /**
+   * Create multiple bands
+   */
+  static createMany(count: number, overrides: Partial<Band> = {}): Band[] {
+    return Array.from({ length: count }, () => this.create(overrides));
+  }
+
+  /**
+   * Create a band with specific technology
+   */
+  static createWithTechnology(
+    technology: string,
+    overrides: Partial<Band> = {}
+  ): Band {
+    const bandNumber = faker.helpers.arrayElement(
+      this.bandNumbersByTech[technology] || ["1"]
+    );
+    return this.create({ technology, bandNumber, ...overrides });
+  }
+
+  /**
+   * Create multiple bands for a specific technology
+   */
+  static createManyForTechnology(
+    technology: string,
+    count: number,
+    overrides: Partial<Band> = {}
+  ): Band[] {
+    return Array.from({ length: count }, () =>
+      this.createWithTechnology(technology, overrides)
+    );
+  }
+
+  /**
+   * Create a complete set of LTE bands
+   */
+  static createLTEBands(): Band[] {
+    return this.bandNumbersByTech["LTE"].map((bandNumber) =>
+      this.create({ technology: "LTE", bandNumber })
+    );
+  }
+
+  /**
+   * Create a complete set of 5G NR bands
+   */
+  static create5GBands(): Band[] {
+    return this.bandNumbersByTech["5G NR"].map((bandNumber) =>
+      this.create({ technology: "5G NR", bandNumber })
+    );
+  }
+
+  /**
+   * Reset the ID counter (call this in beforeEach)
+   */
+  static reset() {
+    this.idCounter = 1;
+  }
+}

--- a/packages/backend/tests/factories/combo.factory.ts
+++ b/packages/backend/tests/factories/combo.factory.ts
@@ -55,8 +55,6 @@ export class ComboFactory {
       id: this.idCounter++,
       technology,
       name,
-      createdAt: new Date(),
-      updatedAt: new Date(),
       ...overrides,
     };
   }

--- a/packages/backend/tests/factories/combo.factory.ts
+++ b/packages/backend/tests/factories/combo.factory.ts
@@ -1,0 +1,131 @@
+import { faker } from "@faker-js/faker";
+import type { combo } from "../../src/db/schema";
+
+type Combo = typeof combo.$inferSelect;
+
+export class ComboFactory {
+  private static idCounter = 1;
+
+  private static technologies = ["LTE", "5G NR", "LTE-A"];
+
+  // Realistic combo names based on technology
+  private static comboNamesByTech: Record<string, string[]> = {
+    LTE: [
+      "2A-4A",
+      "2A-5A",
+      "4A-12A",
+      "2A-4A-12A",
+      "4A-66A",
+      "2A-4A-5A",
+      "2A-4A-66A",
+      "4A-5A-7A",
+    ],
+    "5G NR": [
+      "n77A",
+      "n78A",
+      "n77A-n78A",
+      "n41A-n77A",
+      "n1A-n77A",
+      "n71A-n77A",
+      "n2A-n77A-n78A",
+      "n5A-n77A",
+    ],
+    "LTE-A": [
+      "2A-4A-5A-7A",
+      "2A-4A-12A-66A",
+      "4A-5A-7A-66A",
+      "2A-4A-5A-12A-66A",
+      "4A-12A-66A",
+    ],
+  };
+
+  /**
+   * Create a combo with default or overridden properties
+   */
+  static create(overrides: Partial<Combo> = {}): Combo {
+    const technology =
+      overrides.technology || faker.helpers.arrayElement(this.technologies);
+    const name =
+      overrides.name ||
+      faker.helpers.arrayElement(
+        this.comboNamesByTech[technology] || ["2A-4A"]
+      );
+
+    return {
+      id: this.idCounter++,
+      technology,
+      name,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...overrides,
+    };
+  }
+
+  /**
+   * Create multiple combos
+   */
+  static createMany(count: number, overrides: Partial<Combo> = {}): Combo[] {
+    return Array.from({ length: count }, () => this.create(overrides));
+  }
+
+  /**
+   * Create a combo with specific technology
+   */
+  static createWithTechnology(
+    technology: string,
+    overrides: Partial<Combo> = {}
+  ): Combo {
+    const name = faker.helpers.arrayElement(
+      this.comboNamesByTech[technology] || ["2A-4A"]
+    );
+    return this.create({ technology, name, ...overrides });
+  }
+
+  /**
+   * Create multiple combos for a specific technology
+   */
+  static createManyForTechnology(
+    technology: string,
+    count: number,
+    overrides: Partial<Combo> = {}
+  ): Combo[] {
+    return Array.from({ length: count }, () =>
+      this.createWithTechnology(technology, overrides)
+    );
+  }
+
+  /**
+   * Create a combo with specific name
+   */
+  static createWithName(name: string, overrides: Partial<Combo> = {}): Combo {
+    return this.create({ name, ...overrides });
+  }
+
+  /**
+   * Create LTE combos
+   */
+  static createLTECombos(count = 5): Combo[] {
+    return this.createManyForTechnology("LTE", count);
+  }
+
+  /**
+   * Create 5G NR combos
+   */
+  static create5GCombos(count = 5): Combo[] {
+    return this.createManyForTechnology("5G NR", count);
+  }
+
+  /**
+   * Create LTE-Advanced combos
+   */
+  static createLTEAdvancedCombos(count = 5): Combo[] {
+    return this.createManyForTechnology("LTE-A", count);
+  }
+
+  /**
+   * Reset the ID counter (call this in beforeEach)
+   */
+  static reset() {
+    this.idCounter = 1;
+  }
+}

--- a/packages/backend/tests/factories/device-capability.factory.ts
+++ b/packages/backend/tests/factories/device-capability.factory.ts
@@ -1,5 +1,5 @@
 import { faker } from "@faker-js/faker";
-import type { DeviceCapabilityResult } from "../../repositories/types";
+import type { DeviceCapabilityResult } from "../../src/repositories/types";
 import { DeviceFactory } from "./device.factory";
 import { SoftwareFactory } from "./software.factory";
 

--- a/packages/backend/tests/factories/device-capability.factory.ts
+++ b/packages/backend/tests/factories/device-capability.factory.ts
@@ -1,0 +1,56 @@
+import { faker } from "@faker-js/faker";
+import type { DeviceCapabilityResult } from "../../repositories/types";
+import { DeviceFactory } from "./device.factory";
+import { SoftwareFactory } from "./software.factory";
+
+export class DeviceCapabilityFactory {
+  /**
+   * Create a device capability result (global support)
+   */
+  static createGlobal(
+    overrides: Partial<DeviceCapabilityResult> = {}
+  ): DeviceCapabilityResult {
+    return {
+      device: DeviceFactory.create(),
+      software: SoftwareFactory.createMany(
+        faker.number.int({ min: 1, max: 3 })
+      ),
+      supportStatus: "global",
+      provider: null,
+      ...overrides,
+    };
+  }
+
+  /**
+   * Create a device capability result (provider-specific support)
+   */
+  static createProviderSpecific(
+    providerId: number,
+    overrides: Partial<DeviceCapabilityResult> = {}
+  ): DeviceCapabilityResult {
+    return {
+      device: DeviceFactory.create(),
+      software: SoftwareFactory.createMany(
+        faker.number.int({ min: 1, max: 3 })
+      ),
+      supportStatus: "provider-specific",
+      provider: { providerId },
+      ...overrides,
+    };
+  }
+
+  /**
+   * Create multiple device capability results
+   */
+  static createMany(
+    count: number,
+    isProviderSpecific = false,
+    providerId?: number
+  ): DeviceCapabilityResult[] {
+    return Array.from({ length: count }, () =>
+      isProviderSpecific && providerId
+        ? this.createProviderSpecific(providerId)
+        : this.createGlobal()
+    );
+  }
+}

--- a/packages/backend/tests/factories/device.factory.ts
+++ b/packages/backend/tests/factories/device.factory.ts
@@ -16,8 +16,6 @@ export class DeviceFactory {
       modelNum: faker.string.alphanumeric(8).toUpperCase(),
       marketName: faker.commerce.productName(),
       releaseDate: faker.date.past({ years: 3 }).toISOString().split("T")[0],
-      createdAt: new Date(),
-      updatedAt: new Date(),
       ...overrides,
     };
   }

--- a/packages/backend/tests/factories/device.factory.ts
+++ b/packages/backend/tests/factories/device.factory.ts
@@ -1,0 +1,69 @@
+import { faker } from "@faker-js/faker";
+import type { device } from "../../src/db/schema";
+
+type Device = typeof device.$inferSelect;
+
+export class DeviceFactory {
+  private static idCounter = 1;
+
+  /**
+   * Create a device with default or overridden properties
+   */
+  static create(overrides: Partial<Device> = {}): Device {
+    return {
+      id: this.idCounter++,
+      vendor: faker.company.name(),
+      modelNum: faker.string.alphanumeric(8).toUpperCase(),
+      marketName: faker.commerce.productName(),
+      releaseDate: faker.date.past({ years: 3 }).toISOString().split("T")[0],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...overrides,
+    };
+  }
+
+  /**
+   * Create multiple devices
+   */
+  static createMany(
+    count: number,
+    overrides: Partial<Device> = {}
+  ): Device[] {
+    return Array.from({ length: count }, () => this.create(overrides));
+  }
+
+  /**
+   * Create devices with specific vendors (useful for testing filters)
+   */
+  static createWithVendor(
+    vendor: string,
+    overrides: Partial<Device> = {}
+  ): Device {
+    return this.create({ vendor, ...overrides });
+  }
+
+  /**
+   * Create devices with specific date range
+   */
+  static createWithDateRange(
+    startDate: string,
+    endDate: string,
+    overrides: Partial<Device> = {}
+  ): Device {
+    const start = new Date(startDate);
+    const end = new Date(endDate);
+    const releaseDate = faker.date
+      .between({ from: start, to: end })
+      .toISOString()
+      .split("T")[0];
+
+    return this.create({ releaseDate, ...overrides });
+  }
+
+  /**
+   * Reset the ID counter (call this in beforeEach)
+   */
+  static reset() {
+    this.idCounter = 1;
+  }
+}

--- a/packages/backend/tests/factories/device.factory.ts
+++ b/packages/backend/tests/factories/device.factory.ts
@@ -25,10 +25,7 @@ export class DeviceFactory {
   /**
    * Create multiple devices
    */
-  static createMany(
-    count: number,
-    overrides: Partial<Device> = {}
-  ): Device[] {
+  static createMany(count: number, overrides: Partial<Device> = {}): Device[] {
     return Array.from({ length: count }, () => this.create(overrides));
   }
 

--- a/packages/backend/tests/factories/feature.factory.ts
+++ b/packages/backend/tests/factories/feature.factory.ts
@@ -42,8 +42,7 @@ export class FeatureFactory {
     return {
       id: this.idCounter++,
       name: overrides.name || faker.helpers.arrayElement(this.featureNames),
-      createdAt: new Date(),
-      updatedAt: new Date(),
+      description: "A description of the feature",
       ...overrides,
     };
   }

--- a/packages/backend/tests/factories/feature.factory.ts
+++ b/packages/backend/tests/factories/feature.factory.ts
@@ -1,0 +1,122 @@
+import { faker } from "@faker-js/faker";
+import type { feature } from "../../src/db/schema";
+
+type Feature = typeof feature.$inferSelect;
+
+export class FeatureFactory {
+  private static idCounter = 1;
+
+  // Realistic feature names for mobile devices
+  private static featureNames = [
+    "VoLTE",
+    "VoNR",
+    "Wi-Fi Calling",
+    "Video Calling",
+    "RCS Messaging",
+    "eSIM",
+    "Dual SIM",
+    "HD Voice",
+    "EVS Codec",
+    "MIMO 4x4",
+    "Carrier Aggregation",
+    "Beamforming",
+    "eMBMS",
+    "HPUE",
+    "LAA",
+    "NR-DC",
+    "EN-DC",
+    "SMS over IMS",
+    "Emergency Calling",
+    "Location Services",
+    "Network Slicing",
+    "256 QAM",
+    "Uplink 64 QAM",
+    "TTI Bundling",
+    "Power Class 2",
+  ];
+
+  /**
+   * Create a feature with default or overridden properties
+   */
+  static create(overrides: Partial<Feature> = {}): Feature {
+    return {
+      id: this.idCounter++,
+      name: overrides.name || faker.helpers.arrayElement(this.featureNames),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...overrides,
+    };
+  }
+
+  /**
+   * Create multiple features
+   */
+  static createMany(
+    count: number,
+    overrides: Partial<Feature> = {}
+  ): Feature[] {
+    return Array.from({ length: count }, () => this.create(overrides));
+  }
+
+  /**
+   * Create a feature with specific name
+   */
+  static createWithName(
+    name: string,
+    overrides: Partial<Feature> = {}
+  ): Feature {
+    return this.create({ name, ...overrides });
+  }
+
+  /**
+   * Create common voice features
+   */
+  static createVoiceFeatures(): Feature[] {
+    return [
+      this.create({ name: "VoLTE" }),
+      this.create({ name: "VoNR" }),
+      this.create({ name: "Wi-Fi Calling" }),
+      this.create({ name: "Video Calling" }),
+      this.create({ name: "HD Voice" }),
+      this.create({ name: "EVS Codec" }),
+    ];
+  }
+
+  /**
+   * Create common SIM features
+   */
+  static createSIMFeatures(): Feature[] {
+    return [this.create({ name: "eSIM" }), this.create({ name: "Dual SIM" })];
+  }
+
+  /**
+   * Create common 5G features
+   */
+  static create5GFeatures(): Feature[] {
+    return [
+      this.create({ name: "VoNR" }),
+      this.create({ name: "NR-DC" }),
+      this.create({ name: "EN-DC" }),
+      this.create({ name: "Network Slicing" }),
+    ];
+  }
+
+  /**
+   * Create common carrier aggregation features
+   */
+  static createCAFeatures(): Feature[] {
+    return [
+      this.create({ name: "Carrier Aggregation" }),
+      this.create({ name: "LAA" }),
+      this.create({ name: "MIMO 4x4" }),
+      this.create({ name: "Beamforming" }),
+    ];
+  }
+
+  /**
+   * Reset the ID counter (call this in beforeEach)
+   */
+  static reset() {
+    this.idCounter = 1;
+  }
+}

--- a/packages/backend/tests/factories/provider.factory.ts
+++ b/packages/backend/tests/factories/provider.factory.ts
@@ -74,8 +74,8 @@ export class ProviderFactory {
     return {
       id: this.idCounter++,
       name: overrides.name || faker.helpers.arrayElement(allProviders),
-      createdAt: new Date(),
-      updatedAt: new Date(),
+      country: "US",
+      networkType: "5G",
       ...overrides,
     };
   }

--- a/packages/backend/tests/factories/provider.factory.ts
+++ b/packages/backend/tests/factories/provider.factory.ts
@@ -1,0 +1,195 @@
+import { faker } from "@faker-js/faker";
+import type { provider } from "../../src/db/schema";
+
+type Provider = typeof provider.$inferSelect;
+
+export class ProviderFactory {
+  private static idCounter = 1;
+
+  // Realistic carrier/provider names by region
+  private static providers = {
+    us: [
+      "Verizon",
+      "AT&T",
+      "T-Mobile",
+      "Sprint",
+      "US Cellular",
+      "Dish Wireless",
+      "Boost Mobile",
+      "Cricket Wireless",
+      "Metro by T-Mobile",
+      "Visible",
+      "Mint Mobile",
+      "Google Fi",
+    ],
+    canada: [
+      "Rogers",
+      "Bell",
+      "Telus",
+      "Freedom Mobile",
+      "Videotron",
+      "SaskTel",
+      "Fido",
+      "Koodo",
+      "Virgin Plus",
+    ],
+    uk: [
+      "EE",
+      "O2",
+      "Vodafone",
+      "Three",
+      "Sky Mobile",
+      "Tesco Mobile",
+      "giffgaff",
+      "Smarty",
+    ],
+    europe: [
+      "Orange",
+      "Vodafone",
+      "Telefonica",
+      "Deutsche Telekom",
+      "Swisscom",
+      "KPN",
+      "Telenor",
+      "Telia",
+    ],
+    asia: [
+      "NTT Docomo",
+      "KDDI",
+      "SoftBank",
+      "China Mobile",
+      "China Unicom",
+      "Singtel",
+      "SK Telecom",
+      "KT Corporation",
+    ],
+  };
+
+  /**
+   * Create a provider with default or overridden properties
+   */
+  static create(overrides: Partial<Provider> = {}): Provider {
+    const allProviders = Object.values(this.providers).flat();
+
+    return {
+      id: this.idCounter++,
+      name: overrides.name || faker.helpers.arrayElement(allProviders),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      ...overrides,
+    };
+  }
+
+  /**
+   * Create multiple providers
+   */
+  static createMany(
+    count: number,
+    overrides: Partial<Provider> = {}
+  ): Provider[] {
+    return Array.from({ length: count }, () => this.create(overrides));
+  }
+
+  /**
+   * Create a provider with specific name
+   */
+  static createWithName(
+    name: string,
+    overrides: Partial<Provider> = {}
+  ): Provider {
+    return this.create({ name, ...overrides });
+  }
+
+  /**
+   * Create US providers
+   */
+  static createUSProviders(count?: number): Provider[] {
+    const providers = count
+      ? this.providers.us.slice(0, count)
+      : this.providers.us;
+    return providers.map((name) => this.create({ name }));
+  }
+
+  /**
+   * Create Canadian providers
+   */
+  static createCanadianProviders(count?: number): Provider[] {
+    const providers = count
+      ? this.providers.canada.slice(0, count)
+      : this.providers.canada;
+    return providers.map((name) => this.create({ name }));
+  }
+
+  /**
+   * Create UK providers
+   */
+  static createUKProviders(count?: number): Provider[] {
+    const providers = count
+      ? this.providers.uk.slice(0, count)
+      : this.providers.uk;
+    return providers.map((name) => this.create({ name }));
+  }
+
+  /**
+   * Create European providers
+   */
+  static createEuropeanProviders(count?: number): Provider[] {
+    const providers = count
+      ? this.providers.europe.slice(0, count)
+      : this.providers.europe;
+    return providers.map((name) => this.create({ name }));
+  }
+
+  /**
+   * Create Asian providers
+   */
+  static createAsianProviders(count?: number): Provider[] {
+    const providers = count
+      ? this.providers.asia.slice(0, count)
+      : this.providers.asia;
+    return providers.map((name) => this.create({ name }));
+  }
+
+  /**
+   * Create major US carriers (big 3)
+   */
+  static createMajorUSCarriers(): Provider[] {
+    return [
+      this.create({ name: "Verizon" }),
+      this.create({ name: "AT&T" }),
+      this.create({ name: "T-Mobile" }),
+    ];
+  }
+
+  /**
+   * Create major Canadian carriers (big 3)
+   */
+  static createMajorCanadianCarriers(): Provider[] {
+    return [
+      this.create({ name: "Rogers" }),
+      this.create({ name: "Bell" }),
+      this.create({ name: "Telus" }),
+    ];
+  }
+
+  /**
+   * Create MVNOs (Mobile Virtual Network Operators)
+   */
+  static createMVNOs(): Provider[] {
+    return [
+      this.create({ name: "Boost Mobile" }),
+      this.create({ name: "Cricket Wireless" }),
+      this.create({ name: "Metro by T-Mobile" }),
+      this.create({ name: "Visible" }),
+      this.create({ name: "Mint Mobile" }),
+      this.create({ name: "Google Fi" }),
+    ];
+  }
+
+  /**
+   * Reset the ID counter (call this in beforeEach)
+   */
+  static reset() {
+    this.idCounter = 1;
+  }
+}

--- a/packages/backend/tests/factories/software.factory.ts
+++ b/packages/backend/tests/factories/software.factory.ts
@@ -7,18 +7,16 @@ export class SoftwareFactory {
   private static idCounter = 1;
 
   private static platforms = ["Android", "iOS", "Windows", "macOS", "Linux"];
-  private static versionFormats = [
-    () => `${faker.number.int({ min: 1, max: 15 })}.0`,
-    () =>
-      `${faker.number.int({ min: 1, max: 15 })}.${faker.number.int({
-        min: 0,
-        max: 9,
-      })}`,
-    () =>
-      `${faker.number.int({ min: 1, max: 15 })}.${faker.number.int({
-        min: 0,
-        max: 9,
-      })}.${faker.number.int({ min: 0, max: 99 })}`,
+
+  private static softwareNames = [
+    "System Firmware",
+    "Device Manager",
+    "Core Services",
+    "Network Stack",
+    "Security Module",
+    "Boot Loader",
+    "Update Agent",
+    "Diagnostics Suite",
   ];
 
   /**
@@ -27,12 +25,28 @@ export class SoftwareFactory {
   static create(overrides: Partial<Software> = {}): Software {
     return {
       id: this.idCounter++,
-      deviceId: faker.number.int({ min: 1, max: 1000 }),
+      name: faker.helpers.arrayElement(this.softwareNames),
       platform: faker.helpers.arrayElement(this.platforms),
-      version: faker.helpers.arrayElement(this.versionFormats)(),
+      ptcrb:
+        faker.helpers.maybe(
+          () => faker.number.int({ min: 10000, max: 99999 }),
+          { probability: 0.7 }
+        ) ?? null,
+      svn:
+        faker.helpers.maybe(() => faker.number.int({ min: 1, max: 999 }), {
+          probability: 0.7,
+        }) ?? null,
+      buildNumber:
+        faker.helpers.maybe(
+          () =>
+            `${faker.number.int({ min: 1, max: 15 })}.${faker.number.int({
+              min: 0,
+              max: 9,
+            })}.${faker.number.int({ min: 0, max: 99 })}`,
+          { probability: 0.8 }
+        ) ?? null,
       releaseDate: faker.date.past({ years: 2 }).toISOString().split("T")[0],
-      createdAt: new Date(),
-      updatedAt: new Date(),
+      deviceId: faker.number.int({ min: 1, max: 1000 }),
       ...overrides,
     };
   }
@@ -112,16 +126,16 @@ export class SoftwareFactory {
    */
   static createVersionHistory(
     deviceId: number,
-    versions: string[],
+    buildNumbers: string[],
     overrides: Partial<Software> = {}
   ): Software[] {
-    return versions.map((version, index) => {
+    return buildNumbers.map((buildNumber, index) => {
       const date = new Date();
-      date.setMonth(date.getMonth() - (versions.length - index));
+      date.setMonth(date.getMonth() - (buildNumbers.length - index));
 
       return this.create({
         deviceId,
-        version,
+        buildNumber,
         releaseDate: date.toISOString().split("T")[0],
         ...overrides,
       });

--- a/packages/backend/tests/repositories/band.repository.test.ts
+++ b/packages/backend/tests/repositories/band.repository.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { BandRepository } from "../../src/repositories/band.repository";
 import { BandFactory } from "../factories/band.factory";
-import { DeviceCapabilityFactory } from "../factories/device-capability.factory";
 import { DeviceFactory } from "../factories/device.factory";
 import { SoftwareFactory } from "../factories/software.factory";
 import { db } from "../../src/db/client";
@@ -43,8 +42,8 @@ describe("BandRepository", () => {
       orderBy: vi.fn().mockReturnThis(),
     };
 
-    vi.mocked(db.select).mockReturnValue(mockSelect);
-    vi.mocked(db.selectDistinct).mockReturnValue(mockSelectDistinct);
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(mockSelect);
+    (db.selectDistinct as ReturnType<typeof vi.fn>).mockReturnValue(mockSelectDistinct);
   });
 
   afterEach(() => {

--- a/packages/backend/tests/repositories/band.repository.test.ts
+++ b/packages/backend/tests/repositories/band.repository.test.ts
@@ -1,0 +1,562 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { BandRepository } from "../../src/repositories/band.repository";
+import { BandFactory } from "../factories/band.factory";
+import { DeviceCapabilityFactory } from "../factories/device-capability.factory";
+import { DeviceFactory } from "../factories/device.factory";
+import { SoftwareFactory } from "../factories/software.factory";
+import { db } from "../../src/db/client";
+
+// Mock the database
+vi.mock("../../src/db/client", () => ({
+  db: {
+    select: vi.fn(),
+    selectDistinct: vi.fn(),
+  },
+}));
+
+describe("BandRepository", () => {
+  let repository: BandRepository;
+  let mockSelect: any;
+  let mockSelectDistinct: any;
+
+  beforeEach(() => {
+    BandFactory.reset();
+    DeviceFactory.reset();
+    SoftwareFactory.reset();
+    repository = new BandRepository();
+
+    // Setup chainable mocks for regular select
+    mockSelect = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
+      then: vi.fn().mockReturnThis(),
+    };
+
+    // Setup chainable mocks for selectDistinct
+    mockSelectDistinct = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+    };
+
+    vi.mocked(db.select).mockReturnValue(mockSelect);
+    vi.mocked(db.selectDistinct).mockReturnValue(mockSelectDistinct);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("findById", () => {
+    it("should return band when found", async () => {
+      const mockBand = BandFactory.create({ id: 1 });
+      mockSelect.limit.mockResolvedValue([mockBand]);
+
+      const result = await repository.findById(1);
+
+      expect(result).toEqual(mockBand);
+      expect(db.select).toHaveBeenCalled();
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(mockSelect.limit).toHaveBeenCalledWith(1);
+    });
+
+    it("should return null when band not found", async () => {
+      mockSelect.limit.mockResolvedValue([]);
+
+      const result = await repository.findById(999);
+
+      expect(result).toBeNull();
+    });
+
+    it("should handle valid ID parameter", async () => {
+      mockSelect.limit.mockResolvedValue([]);
+
+      await repository.findById(42);
+
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(mockSelect.limit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("findByIds", () => {
+    it("should return empty array when given empty array", async () => {
+      const result = await repository.findByIds([]);
+
+      expect(result).toEqual([]);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it("should return multiple bands for valid IDs", async () => {
+      const mockBands = BandFactory.createMany(3);
+      mockSelect.where.mockResolvedValue(mockBands);
+
+      const result = await repository.findByIds([1, 2, 3]);
+
+      expect(result).toEqual(mockBands);
+      expect(result).toHaveLength(3);
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should handle single ID in array", async () => {
+      const mockBand = BandFactory.create({ id: 1 });
+      mockSelect.where.mockResolvedValue([mockBand]);
+
+      const result = await repository.findByIds([1]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(mockBand);
+    });
+
+    it("should handle large array of IDs", async () => {
+      const ids = Array.from({ length: 100 }, (_, i) => i + 1);
+      const mockBands = BandFactory.createMany(100);
+      mockSelect.where.mockResolvedValue(mockBands);
+
+      const result = await repository.findByIds(ids);
+
+      expect(result).toHaveLength(100);
+    });
+  });
+
+  describe("search", () => {
+    it("should return all bands when no filters provided", async () => {
+      const mockBands = BandFactory.createMany(5);
+      mockSelect.orderBy.mockResolvedValue(mockBands);
+
+      const result = await repository.search();
+
+      expect(result).toEqual(mockBands);
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+
+    it("should filter by technology", async () => {
+      const lteBands = BandFactory.createManyForTechnology("LTE", 3);
+      mockSelect.orderBy.mockResolvedValue(lteBands);
+
+      const result = await repository.search({ technology: "LTE" });
+
+      expect(result.every((b) => b.technology === "LTE")).toBe(true);
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should filter by band number using LIKE", async () => {
+      const band = BandFactory.create({ bandNumber: "66" });
+      mockSelect.orderBy.mockResolvedValue([band]);
+
+      const result = await repository.search({ bandNumber: "66" });
+
+      expect(result[0].bandNumber).toBe("66");
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should combine technology and band number filters", async () => {
+      const band = BandFactory.create({
+        technology: "5G NR",
+        bandNumber: "n77",
+      });
+      mockSelect.orderBy.mockResolvedValue([band]);
+
+      const result = await repository.search({
+        technology: "5G NR",
+        bandNumber: "n77",
+      });
+
+      expect(result[0].technology).toBe("5G NR");
+      expect(result[0].bandNumber).toBe("n77");
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should handle partial band number matches", async () => {
+      const bands = [
+        BandFactory.create({ bandNumber: "n77" }),
+        BandFactory.create({ bandNumber: "n78" }),
+      ];
+      mockSelect.orderBy.mockResolvedValue(bands);
+
+      const result = await repository.search({ bandNumber: "n7" });
+
+      expect(result).toHaveLength(2);
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should return empty array when no bands match filters", async () => {
+      mockSelect.orderBy.mockResolvedValue([]);
+
+      const result = await repository.search({ technology: "NonExistentTech" });
+
+      expect(result).toEqual([]);
+    });
+
+    it("should order results by technology and band number", async () => {
+      const mockBands = BandFactory.createMany(5);
+      mockSelect.orderBy.mockResolvedValue(mockBands);
+
+      await repository.search();
+
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+  });
+
+  describe("findAll", () => {
+    it("should return all bands ordered by technology and band number", async () => {
+      const mockBands = [
+        BandFactory.createWithTechnology("LTE"),
+        BandFactory.createWithTechnology("5G NR"),
+        BandFactory.createWithTechnology("UMTS"),
+      ];
+      mockSelect.orderBy.mockResolvedValue(mockBands);
+
+      const result = await repository.findAll();
+
+      expect(result).toEqual(mockBands);
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+
+    it("should return empty array when no bands exist", async () => {
+      mockSelect.orderBy.mockResolvedValue([]);
+
+      const result = await repository.findAll();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("findDevicesSupportingBand", () => {
+    const bandId = 1;
+
+    describe("global capability queries (no providerId)", () => {
+      it("should return devices supporting a band globally", async () => {
+        const device1 = DeviceFactory.create({ id: 1 });
+        const device2 = DeviceFactory.create({ id: 2 });
+        const software1 = SoftwareFactory.create({ deviceId: 1 });
+        const software2 = SoftwareFactory.create({ deviceId: 2 });
+
+        const mockResults = [
+          { device: device1, software: software1 },
+          { device: device2, software: software2 },
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingBand({ bandId });
+
+        expect(result).toHaveLength(2);
+        expect(result[0].supportStatus).toBe("global");
+        expect(result[0].provider).toBeNull();
+        expect(result[0].device.id).toBe(1);
+        expect(result[1].device.id).toBe(2);
+      });
+
+      it("should group software by device", async () => {
+        const device = DeviceFactory.create({ id: 1 });
+        const software1 = SoftwareFactory.create({ id: 1, deviceId: 1 });
+        const software2 = SoftwareFactory.create({ id: 2, deviceId: 1 });
+
+        const mockResults = [
+          { device, software: software1 },
+          { device, software: software2 },
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingBand({ bandId });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].software).toHaveLength(2);
+        expect(result[0].software[0].id).toBe(1);
+        expect(result[0].software[1].id).toBe(2);
+      });
+
+      it("should filter by technology when provided", async () => {
+        const device = DeviceFactory.create();
+        const software = SoftwareFactory.create();
+        const mockResults = [{ device, software }];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingBand({
+          bandId,
+          technology: "5G NR",
+        });
+
+        expect(mockSelectDistinct.where).toHaveBeenCalled();
+        expect(result).toHaveLength(1);
+      });
+
+      it("should return empty array when no devices support the band", async () => {
+        mockSelectDistinct.orderBy.mockResolvedValue([]);
+
+        const result = await repository.findDevicesSupportingBand({ bandId });
+
+        expect(result).toEqual([]);
+      });
+
+      it("should deduplicate software entries for same device", async () => {
+        const device = DeviceFactory.create({ id: 1 });
+        const software = SoftwareFactory.create({ id: 1, deviceId: 1 });
+
+        // Simulating duplicate rows from join
+        const mockResults = [
+          { device, software },
+          { device, software }, // duplicate
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingBand({ bandId });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].software).toHaveLength(1);
+      });
+    });
+
+    describe("provider-specific capability queries", () => {
+      const providerId = 10;
+
+      it("should return devices supporting a band for specific provider", async () => {
+        const device1 = DeviceFactory.create({ id: 1 });
+        const device2 = DeviceFactory.create({ id: 2 });
+        const software1 = SoftwareFactory.create({ deviceId: 1 });
+        const software2 = SoftwareFactory.create({ deviceId: 2 });
+
+        const mockResults = [
+          { device: device1, software: software1, providerId },
+          { device: device2, software: software2, providerId },
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingBand({
+          bandId,
+          providerId,
+        });
+
+        expect(result).toHaveLength(2);
+        expect(result[0].supportStatus).toBe("provider-specific");
+        expect(result[0].provider).toEqual({ providerId });
+        expect(result[1].provider).toEqual({ providerId });
+      });
+
+      it("should group software by device for provider-specific query", async () => {
+        const device = DeviceFactory.create({ id: 1 });
+        const software1 = SoftwareFactory.create({ id: 1, deviceId: 1 });
+        const software2 = SoftwareFactory.create({ id: 2, deviceId: 1 });
+
+        const mockResults = [
+          { device, software: software1, providerId },
+          { device, software: software2, providerId },
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingBand({
+          bandId,
+          providerId,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].software).toHaveLength(2);
+      });
+
+      it("should filter by technology for provider-specific query", async () => {
+        const device = DeviceFactory.create();
+        const software = SoftwareFactory.create();
+        const mockResults = [{ device, software, providerId }];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingBand({
+          bandId,
+          providerId,
+          technology: "LTE",
+        });
+
+        expect(mockSelectDistinct.where).toHaveBeenCalled();
+        expect(result[0].supportStatus).toBe("provider-specific");
+      });
+
+      it("should deduplicate software for provider-specific query", async () => {
+        const device = DeviceFactory.create({ id: 1 });
+        const software = SoftwareFactory.create({ id: 1, deviceId: 1 });
+
+        const mockResults = [
+          { device, software, providerId },
+          { device, software, providerId }, // duplicate
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingBand({
+          bandId,
+          providerId,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].software).toHaveLength(1);
+      });
+    });
+  });
+
+  describe("findByDeviceSoftware", () => {
+    const deviceId = 1;
+    const softwareId = 1;
+
+    it("should return bands for device/software combination", async () => {
+      const bands = BandFactory.createMany(3);
+      const mockResults = bands.map((band) => ({ band }));
+      mockSelect.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelect.where.mockResolvedValue(mockSelect);
+
+      const result = await repository.findByDeviceSoftware(
+        deviceId,
+        softwareId
+      );
+
+      expect(result).toEqual(bands);
+      expect(mockSelect.innerJoin).toHaveBeenCalled();
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should filter by technology when provided", async () => {
+      const bands = BandFactory.createManyForTechnology("LTE", 2);
+      const mockResults = bands.map((band) => ({ band }));
+      mockSelect.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelect.where.mockResolvedValue(mockSelect);
+
+      const result = await repository.findByDeviceSoftware(
+        deviceId,
+        softwareId,
+        "LTE"
+      );
+
+      expect(result).toEqual(bands);
+      expect(result.every((b) => b.technology === "LTE")).toBe(true);
+    });
+
+    it("should return empty array when no bands found", async () => {
+      mockSelect.then.mockImplementation((fn: any) => fn([]));
+      mockSelect.where.mockResolvedValue(mockSelect);
+
+      const result = await repository.findByDeviceSoftware(
+        deviceId,
+        softwareId
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle multiple bands across technologies", async () => {
+      const bands = [
+        BandFactory.createWithTechnology("LTE"),
+        BandFactory.createWithTechnology("5G NR"),
+      ];
+      const mockResults = bands.map((band) => ({ band }));
+      mockSelect.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelect.where.mockResolvedValue(mockSelect);
+
+      const result = await repository.findByDeviceSoftware(
+        deviceId,
+        softwareId
+      );
+
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe("findByDeviceSoftwareProvider", () => {
+    const deviceId = 1;
+    const softwareId = 1;
+    const providerId = 10;
+
+    it("should return bands for device/software/provider combination", async () => {
+      const bands = BandFactory.createMany(3);
+      const mockResults = bands.map((band) => ({ band }));
+      mockSelect.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelect.where.mockResolvedValue(mockSelect);
+
+      const result = await repository.findByDeviceSoftwareProvider(
+        deviceId,
+        softwareId,
+        providerId
+      );
+
+      expect(result).toEqual(bands);
+      expect(mockSelect.innerJoin).toHaveBeenCalled();
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should filter by technology when provided", async () => {
+      const bands = BandFactory.createManyForTechnology("5G NR", 2);
+      const mockResults = bands.map((band) => ({ band }));
+      mockSelect.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelect.where.mockResolvedValue(mockSelect);
+
+      const result = await repository.findByDeviceSoftwareProvider(
+        deviceId,
+        softwareId,
+        providerId,
+        "5G NR"
+      );
+
+      expect(result).toEqual(bands);
+      expect(result.every((b) => b.technology === "5G NR")).toBe(true);
+    });
+
+    it("should return empty array when no bands found", async () => {
+      mockSelect.then.mockImplementation((fn: any) => fn([]));
+      mockSelect.where.mockResolvedValue(mockSelect);
+
+      const result = await repository.findByDeviceSoftwareProvider(
+        deviceId,
+        softwareId,
+        providerId
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle provider-specific band configurations", async () => {
+      const bands = BandFactory.createMany(5);
+      const mockResults = bands.map((band) => ({ band }));
+      mockSelect.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelect.where.mockResolvedValue(mockSelect);
+
+      const result = await repository.findByDeviceSoftwareProvider(
+        deviceId,
+        softwareId,
+        providerId
+      );
+
+      expect(result).toHaveLength(5);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle bands with special characters in band number", async () => {
+      const band = BandFactory.create({ bandNumber: "n77/n78" });
+      mockSelect.limit.mockResolvedValue([band]);
+
+      const result = await repository.findById(1);
+
+      expect(result?.bandNumber).toBe("n77/n78");
+    });
+
+    it("should handle case-sensitive technology filtering", async () => {
+      const bands = BandFactory.createManyForTechnology("5G NR", 2);
+      mockSelect.orderBy.mockResolvedValue(bands);
+
+      const result = await repository.search({ technology: "5G NR" });
+
+      expect(result.every((b) => b.technology === "5G NR")).toBe(true);
+    });
+
+    it("should handle very large result sets for findDevicesSupportingBand", async () => {
+      const devices = Array.from({ length: 100 }, (_, i) => {
+        const device = DeviceFactory.create({ id: i + 1 });
+        const software = SoftwareFactory.create({ deviceId: i + 1 });
+        return { device, software };
+      });
+      mockSelectDistinct.orderBy.mockResolvedValue(devices);
+
+      const result = await repository.findDevicesSupportingBand({ bandId: 1 });
+
+      expect(result).toHaveLength(100);
+    });
+  });
+});

--- a/packages/backend/tests/repositories/combo.repository.test.ts
+++ b/packages/backend/tests/repositories/combo.repository.test.ts
@@ -1,0 +1,797 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { ComboRepository } from "../../src/repositories/combo.repository";
+import { ComboFactory } from "../factories/combo.factory";
+import { BandFactory } from "../factories/band.factory";
+import { DeviceCapabilityFactory } from "../factories/device-capability.factory";
+import { DeviceFactory } from "../factories/device.factory";
+import { SoftwareFactory } from "../factories/software.factory";
+import { db } from "../../src/db/client";
+
+// Mock the database
+vi.mock("../../src/db/client", () => ({
+  db: {
+    select: vi.fn(),
+    selectDistinct: vi.fn(),
+  },
+}));
+
+describe("ComboRepository", () => {
+  let repository: ComboRepository;
+  let mockSelect: any;
+  let mockSelectDistinct: any;
+
+  beforeEach(() => {
+    ComboFactory.reset();
+    BandFactory.reset();
+    DeviceFactory.reset();
+    SoftwareFactory.reset();
+    repository = new ComboRepository();
+
+    // Setup chainable mocks for regular select
+    mockSelect = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
+      then: vi.fn().mockReturnThis(),
+    };
+
+    // Setup chainable mocks for selectDistinct
+    mockSelectDistinct = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+    };
+
+    vi.mocked(db.select).mockReturnValue(mockSelect);
+    vi.mocked(db.selectDistinct).mockReturnValue(mockSelectDistinct);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("findById", () => {
+    it("should return combo when found", async () => {
+      const mockCombo = ComboFactory.create({ id: 1 });
+      mockSelect.limit.mockResolvedValue([mockCombo]);
+
+      const result = await repository.findById(1);
+
+      expect(result).toEqual(mockCombo);
+      expect(db.select).toHaveBeenCalled();
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(mockSelect.limit).toHaveBeenCalledWith(1);
+    });
+
+    it("should return null when combo not found", async () => {
+      mockSelect.limit.mockResolvedValue([]);
+
+      const result = await repository.findById(999);
+
+      expect(result).toBeNull();
+    });
+
+    it("should handle valid ID parameter", async () => {
+      mockSelect.limit.mockResolvedValue([]);
+
+      await repository.findById(42);
+
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(mockSelect.limit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("findByIds", () => {
+    it("should return empty array when given empty array", async () => {
+      const result = await repository.findByIds([]);
+
+      expect(result).toEqual([]);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it("should return multiple combos for valid IDs", async () => {
+      const mockCombos = ComboFactory.createMany(3);
+      mockSelect.where.mockResolvedValue(mockCombos);
+
+      const result = await repository.findByIds([1, 2, 3]);
+
+      expect(result).toEqual(mockCombos);
+      expect(result).toHaveLength(3);
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should handle single ID in array", async () => {
+      const mockCombo = ComboFactory.create({ id: 1 });
+      mockSelect.where.mockResolvedValue([mockCombo]);
+
+      const result = await repository.findByIds([1]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(mockCombo);
+    });
+
+    it("should handle large array of IDs", async () => {
+      const ids = Array.from({ length: 100 }, (_, i) => i + 1);
+      const mockCombos = ComboFactory.createMany(100);
+      mockSelect.where.mockResolvedValue(mockCombos);
+
+      const result = await repository.findByIds(ids);
+
+      expect(result).toHaveLength(100);
+    });
+  });
+
+  describe("search", () => {
+    it("should return all combos when no filters provided", async () => {
+      const mockCombos = ComboFactory.createMany(5);
+      mockSelect.orderBy.mockResolvedValue(mockCombos);
+
+      const result = await repository.search();
+
+      expect(result).toEqual(mockCombos);
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+
+    it("should filter by technology", async () => {
+      const lteCombos = ComboFactory.createManyForTechnology("LTE", 3);
+      mockSelect.orderBy.mockResolvedValue(lteCombos);
+
+      const result = await repository.search({ technology: "LTE" });
+
+      expect(result.every((c) => c.technology === "LTE")).toBe(true);
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should filter by name using LIKE", async () => {
+      const combo = ComboFactory.createWithName("2A-4A");
+      mockSelect.orderBy.mockResolvedValue([combo]);
+
+      const result = await repository.search({ name: "2A-4A" });
+
+      expect(result[0].name).toBe("2A-4A");
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should combine technology and name filters", async () => {
+      const combo = ComboFactory.create({
+        technology: "5G NR",
+        name: "n77A-n78A",
+      });
+      mockSelect.orderBy.mockResolvedValue([combo]);
+
+      const result = await repository.search({
+        technology: "5G NR",
+        name: "n77A",
+      });
+
+      expect(result[0].technology).toBe("5G NR");
+      expect(result[0].name).toContain("n77A");
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should handle partial name matches", async () => {
+      const combos = [
+        ComboFactory.createWithName("2A-4A"),
+        ComboFactory.createWithName("2A-4A-12A"),
+        ComboFactory.createWithName("2A-4A-66A"),
+      ];
+      mockSelect.orderBy.mockResolvedValue(combos);
+
+      const result = await repository.search({ name: "2A-4A" });
+
+      expect(result).toHaveLength(3);
+      expect(result.every((c) => c.name.includes("2A-4A"))).toBe(true);
+    });
+
+    it("should return empty array when no combos match filters", async () => {
+      mockSelect.orderBy.mockResolvedValue([]);
+
+      const result = await repository.search({ technology: "NonExistentTech" });
+
+      expect(result).toEqual([]);
+    });
+
+    it("should order results by technology and name", async () => {
+      const mockCombos = ComboFactory.createMany(5);
+      mockSelect.orderBy.mockResolvedValue(mockCombos);
+
+      await repository.search();
+
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+
+    it("should handle empty filter object", async () => {
+      const mockCombos = ComboFactory.createMany(3);
+      mockSelect.orderBy.mockResolvedValue(mockCombos);
+
+      const result = await repository.search({});
+
+      expect(result).toEqual(mockCombos);
+    });
+  });
+
+  describe("findAll", () => {
+    it("should return all combos ordered by technology and name", async () => {
+      const mockCombos = [
+        ComboFactory.createWithTechnology("LTE"),
+        ComboFactory.createWithTechnology("5G NR"),
+        ComboFactory.createWithTechnology("LTE-A"),
+      ];
+      mockSelect.orderBy.mockResolvedValue(mockCombos);
+
+      const result = await repository.findAll();
+
+      expect(result).toEqual(mockCombos);
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+
+    it("should return empty array when no combos exist", async () => {
+      mockSelect.orderBy.mockResolvedValue([]);
+
+      const result = await repository.findAll();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("findBandsByCombo", () => {
+    const comboId = 1;
+
+    it("should return bands that make up a combo", async () => {
+      const bands = BandFactory.createMany(3);
+      const mockResults = bands.map((band) => ({ band }));
+      mockSelect.where.mockResolvedValue(mockResults);
+
+      const result = await repository.findBandsByCombo(comboId);
+
+      expect(result).toHaveLength(3);
+      expect(mockSelect.innerJoin).toHaveBeenCalled();
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should return empty array when combo has no bands", async () => {
+      mockSelect.where.mockResolvedValue([]);
+
+      const result = await repository.findBandsByCombo(comboId);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle combo with single band", async () => {
+      const band = BandFactory.create();
+      mockSelect.where.mockResolvedValue([{ band }]);
+
+      const result = await repository.findBandsByCombo(comboId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual({ band });
+    });
+
+    it("should handle combo with many bands", async () => {
+      const bands = BandFactory.createMany(10);
+      const mockResults = bands.map((band) => ({ band }));
+      mockSelect.where.mockResolvedValue(mockResults);
+
+      const result = await repository.findBandsByCombo(comboId);
+
+      expect(result).toHaveLength(10);
+    });
+  });
+
+  describe("findBandsByCombos", () => {
+    it("should return empty array when given empty array", async () => {
+      const result = await repository.findBandsByCombos([]);
+
+      expect(result).toEqual([]);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it("should return bands for multiple combos with comboId", async () => {
+      const combo1Bands = BandFactory.createMany(2);
+      const combo2Bands = BandFactory.createMany(3);
+
+      const mockResults = [
+        ...combo1Bands.map((band) => ({ comboId: 1, band })),
+        ...combo2Bands.map((band) => ({ comboId: 2, band })),
+      ];
+      mockSelect.orderBy.mockResolvedValue(mockResults);
+
+      const result = await repository.findBandsByCombos([1, 2]);
+
+      expect(result).toHaveLength(5);
+      expect(result.filter((r) => r.comboId === 1)).toHaveLength(2);
+      expect(result.filter((r) => r.comboId === 2)).toHaveLength(3);
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+
+    it("should handle single combo ID in array", async () => {
+      const bands = BandFactory.createMany(3);
+      const mockResults = bands.map((band) => ({ comboId: 1, band }));
+      mockSelect.orderBy.mockResolvedValue(mockResults);
+
+      const result = await repository.findBandsByCombos([1]);
+
+      expect(result).toHaveLength(3);
+      expect(result.every((r) => r.comboId === 1)).toBe(true);
+    });
+
+    it("should order results by comboId", async () => {
+      const mockResults = [
+        { comboId: 1, band: BandFactory.create() },
+        { comboId: 1, band: BandFactory.create() },
+        { comboId: 2, band: BandFactory.create() },
+      ];
+      mockSelect.orderBy.mockResolvedValue(mockResults);
+
+      await repository.findBandsByCombos([1, 2]);
+
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+
+    it("should handle large batch of combo IDs", async () => {
+      const comboIds = Array.from({ length: 50 }, (_, i) => i + 1);
+      const mockResults = comboIds.flatMap((comboId) =>
+        BandFactory.createMany(2).map((band) => ({ comboId, band }))
+      );
+      mockSelect.orderBy.mockResolvedValue(mockResults);
+
+      const result = await repository.findBandsByCombos(comboIds);
+
+      expect(result).toHaveLength(100);
+    });
+
+    it("should handle combo with no bands gracefully", async () => {
+      const mockResults = [
+        { comboId: 1, band: BandFactory.create() },
+        // combo 2 has no bands
+      ];
+      mockSelect.orderBy.mockResolvedValue(mockResults);
+
+      const result = await repository.findBandsByCombos([1, 2]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].comboId).toBe(1);
+    });
+  });
+
+  describe("findDevicesSupportingCombo", () => {
+    const comboId = 1;
+
+    describe("global capability queries (no providerId)", () => {
+      it("should return devices supporting a combo globally", async () => {
+        const device1 = DeviceFactory.create({ id: 1 });
+        const device2 = DeviceFactory.create({ id: 2 });
+        const software1 = SoftwareFactory.create({ deviceId: 1 });
+        const software2 = SoftwareFactory.create({ deviceId: 2 });
+
+        const mockResults = [
+          { device: device1, software: software1 },
+          { device: device2, software: software2 },
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingCombo({ comboId });
+
+        expect(result).toHaveLength(2);
+        expect(result[0].supportStatus).toBe("global");
+        expect(result[0].provider).toBeNull();
+        expect(result[0].device.id).toBe(1);
+        expect(result[1].device.id).toBe(2);
+      });
+
+      it("should group software by device", async () => {
+        const device = DeviceFactory.create({ id: 1 });
+        const software1 = SoftwareFactory.create({ id: 1, deviceId: 1 });
+        const software2 = SoftwareFactory.create({ id: 2, deviceId: 1 });
+
+        const mockResults = [
+          { device, software: software1 },
+          { device, software: software2 },
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingCombo({ comboId });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].software).toHaveLength(2);
+        expect(result[0].software[0].id).toBe(1);
+        expect(result[0].software[1].id).toBe(2);
+      });
+
+      it("should filter by technology when provided", async () => {
+        const device = DeviceFactory.create();
+        const software = SoftwareFactory.create();
+        const mockResults = [{ device, software }];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingCombo({
+          comboId,
+          technology: "5G NR",
+        });
+
+        expect(mockSelectDistinct.where).toHaveBeenCalled();
+        expect(result).toHaveLength(1);
+      });
+
+      it("should return empty array when no devices support the combo", async () => {
+        mockSelectDistinct.orderBy.mockResolvedValue([]);
+
+        const result = await repository.findDevicesSupportingCombo({ comboId });
+
+        expect(result).toEqual([]);
+      });
+
+      it("should deduplicate software entries for same device", async () => {
+        const device = DeviceFactory.create({ id: 1 });
+        const software = SoftwareFactory.create({ id: 1, deviceId: 1 });
+
+        // Simulating duplicate rows from join
+        const mockResults = [
+          { device, software },
+          { device, software }, // duplicate
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingCombo({ comboId });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].software).toHaveLength(1);
+      });
+
+      it("should handle multiple devices with varying software counts", async () => {
+        const device1 = DeviceFactory.create({ id: 1 });
+        const device2 = DeviceFactory.create({ id: 2 });
+        const software1 = SoftwareFactory.create({ id: 1, deviceId: 1 });
+        const software2 = SoftwareFactory.create({ id: 2, deviceId: 1 });
+        const software3 = SoftwareFactory.create({ id: 3, deviceId: 2 });
+
+        const mockResults = [
+          { device: device1, software: software1 },
+          { device: device1, software: software2 },
+          { device: device2, software: software3 },
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingCombo({ comboId });
+
+        expect(result).toHaveLength(2);
+        expect(result[0].software).toHaveLength(2);
+        expect(result[1].software).toHaveLength(1);
+      });
+    });
+
+    describe("provider-specific capability queries", () => {
+      const providerId = 10;
+
+      it("should return devices supporting a combo for specific provider", async () => {
+        const device1 = DeviceFactory.create({ id: 1 });
+        const device2 = DeviceFactory.create({ id: 2 });
+        const software1 = SoftwareFactory.create({ deviceId: 1 });
+        const software2 = SoftwareFactory.create({ deviceId: 2 });
+
+        const mockResults = [
+          { device: device1, software: software1, providerId },
+          { device: device2, software: software2, providerId },
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingCombo({
+          comboId,
+          providerId,
+        });
+
+        expect(result).toHaveLength(2);
+        expect(result[0].supportStatus).toBe("provider-specific");
+        expect(result[0].provider).toEqual({ providerId });
+        expect(result[1].provider).toEqual({ providerId });
+      });
+
+      it("should group software by device for provider-specific query", async () => {
+        const device = DeviceFactory.create({ id: 1 });
+        const software1 = SoftwareFactory.create({ id: 1, deviceId: 1 });
+        const software2 = SoftwareFactory.create({ id: 2, deviceId: 1 });
+
+        const mockResults = [
+          { device, software: software1, providerId },
+          { device, software: software2, providerId },
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingCombo({
+          comboId,
+          providerId,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].software).toHaveLength(2);
+      });
+
+      it("should filter by technology for provider-specific query", async () => {
+        const device = DeviceFactory.create();
+        const software = SoftwareFactory.create();
+        const mockResults = [{ device, software, providerId }];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingCombo({
+          comboId,
+          providerId,
+          technology: "LTE",
+        });
+
+        expect(mockSelectDistinct.where).toHaveBeenCalled();
+        expect(result[0].supportStatus).toBe("provider-specific");
+      });
+
+      it("should deduplicate software for provider-specific query", async () => {
+        const device = DeviceFactory.create({ id: 1 });
+        const software = SoftwareFactory.create({ id: 1, deviceId: 1 });
+
+        const mockResults = [
+          { device, software, providerId },
+          { device, software, providerId }, // duplicate
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingCombo({
+          comboId,
+          providerId,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].software).toHaveLength(1);
+      });
+
+      it("should return empty array when no devices match provider criteria", async () => {
+        mockSelectDistinct.orderBy.mockResolvedValue([]);
+
+        const result = await repository.findDevicesSupportingCombo({
+          comboId,
+          providerId,
+        });
+
+        expect(result).toEqual([]);
+      });
+    });
+  });
+
+  describe("findByDeviceSoftware", () => {
+    const deviceId = 1;
+    const softwareId = 1;
+
+    it("should return combos for device/software combination", async () => {
+      const combos = ComboFactory.createMany(3);
+      const mockResults = combos.map((combo) => ({ combo }));
+      mockSelect.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelect.where.mockResolvedValue(mockSelect);
+
+      const result = await repository.findByDeviceSoftware(
+        deviceId,
+        softwareId
+      );
+
+      expect(result).toEqual(combos);
+      expect(mockSelect.innerJoin).toHaveBeenCalled();
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should filter by technology when provided", async () => {
+      const combos = ComboFactory.createManyForTechnology("LTE", 2);
+      const mockResults = combos.map((combo) => ({ combo }));
+      mockSelect.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelect.where.mockResolvedValue(mockSelect);
+
+      const result = await repository.findByDeviceSoftware(
+        deviceId,
+        softwareId,
+        "LTE"
+      );
+
+      expect(result).toEqual(combos);
+      expect(result.every((c) => c.technology === "LTE")).toBe(true);
+    });
+
+    it("should return empty array when no combos found", async () => {
+      mockSelect.then.mockImplementation((fn: any) => fn([]));
+      mockSelect.where.mockResolvedValue(mockSelect);
+
+      const result = await repository.findByDeviceSoftware(
+        deviceId,
+        softwareId
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle multiple combos across technologies", async () => {
+      const combos = [
+        ComboFactory.createWithTechnology("LTE"),
+        ComboFactory.createWithTechnology("5G NR"),
+      ];
+      const mockResults = combos.map((combo) => ({ combo }));
+      mockSelect.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelect.where.mockResolvedValue(mockSelect);
+
+      const result = await repository.findByDeviceSoftware(
+        deviceId,
+        softwareId
+      );
+
+      expect(result).toHaveLength(2);
+    });
+
+    it("should handle device/software with many combos", async () => {
+      const combos = ComboFactory.createMany(10);
+      const mockResults = combos.map((combo) => ({ combo }));
+      mockSelect.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelect.where.mockResolvedValue(mockSelect);
+
+      const result = await repository.findByDeviceSoftware(
+        deviceId,
+        softwareId
+      );
+
+      expect(result).toHaveLength(10);
+    });
+  });
+
+  describe("findByDeviceSoftwareProvider", () => {
+    const deviceId = 1;
+    const softwareId = 1;
+    const providerId = 10;
+
+    it("should filter by technology when provided", async () => {
+      const combos = ComboFactory.createManyForTechnology("5G NR", 2);
+      const mockResults = combos.map((combo) => ({ combo }));
+      mockSelect.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelect.where.mockResolvedValue(mockSelect);
+
+      const result = await repository.findByDeviceSoftwareProvider(
+        deviceId,
+        softwareId,
+        providerId,
+        "5G NR"
+      );
+
+      expect(result).toEqual(combos);
+      expect(result.every((c) => c.technology === "5G NR")).toBe(true);
+    });
+
+    it("should return empty array when no combos found", async () => {
+      mockSelect.then.mockImplementation((fn: any) => fn([]));
+      mockSelect.where.mockResolvedValue(mockSelect);
+
+      const result = await repository.findByDeviceSoftwareProvider(
+        deviceId,
+        softwareId,
+        providerId
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return combos for device/software/provider combination", async () => {
+      const combos = ComboFactory.createMany(3);
+      const mockResults = combos.map((combo) => ({ combo }));
+      mockSelect.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelect.where.mockResolvedValue(mockSelect);
+
+      const result = await repository.findByDeviceSoftwareProvider(
+        deviceId,
+        softwareId,
+        providerId
+      );
+
+      expect(result).toHaveLength(5);
+    });
+
+    it("should handle different providers having different combos", async () => {
+      const combos = ComboFactory.createMany(3);
+      const mockResults = combos.map((combo) => ({ combo }));
+      mockSelect.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelect.where.mockResolvedValue(mockSelect);
+
+      const result = await repository.findByDeviceSoftwareProvider(
+        deviceId,
+        softwareId,
+        providerId
+      );
+
+      expect(result).toHaveLength(3);
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle combos with special characters in name", async () => {
+      const combo = ComboFactory.create({ name: "n77A+n78A-CA" });
+      mockSelect.limit.mockResolvedValue([combo]);
+
+      const result = await repository.findById(1);
+
+      expect(result?.name).toBe("n77A+n78A-CA");
+    });
+
+    it("should handle very long combo names", async () => {
+      const longName = "2A-4A-5A-7A-12A-13A-17A-25A-26A-30A-41A-66A-71A";
+      const combo = ComboFactory.create({ name: longName });
+      mockSelect.limit.mockResolvedValue([combo]);
+
+      const result = await repository.findById(1);
+
+      expect(result?.name).toBe(longName);
+    });
+
+    it("should handle case-sensitive technology filtering", async () => {
+      const combos = ComboFactory.createManyForTechnology("5G NR", 2);
+      mockSelect.orderBy.mockResolvedValue(combos);
+
+      const result = await repository.search({ technology: "5G NR" });
+
+      expect(result.every((c) => c.technology === "5G NR")).toBe(true);
+    });
+
+    it("should handle very large result sets for findDevicesSupportingCombo", async () => {
+      const devices = Array.from({ length: 100 }, (_, i) => {
+        const device = DeviceFactory.create({ id: i + 1 });
+        const software = SoftwareFactory.create({ deviceId: i + 1 });
+        return { device, software };
+      });
+      mockSelectDistinct.orderBy.mockResolvedValue(devices);
+
+      const result = await repository.findDevicesSupportingCombo({
+        comboId: 1,
+      });
+
+      expect(result).toHaveLength(100);
+    });
+
+    it("should handle findBandsByCombos with uneven band distributions", async () => {
+      const mockResults = [
+        { comboId: 1, band: BandFactory.create() },
+        { comboId: 2, band: BandFactory.create() },
+        { comboId: 2, band: BandFactory.create() },
+        { comboId: 2, band: BandFactory.create() },
+        { comboId: 3, band: BandFactory.create() },
+        { comboId: 3, band: BandFactory.create() },
+      ];
+      mockSelect.orderBy.mockResolvedValue(mockResults);
+
+      const result = await repository.findBandsByCombos([1, 2, 3]);
+
+      expect(result.filter((r) => r.comboId === 1)).toHaveLength(1);
+      expect(result.filter((r) => r.comboId === 2)).toHaveLength(3);
+      expect(result.filter((r) => r.comboId === 3)).toHaveLength(2);
+    });
+
+    it("should handle mixed technology results in findDevicesSupportingCombo", async () => {
+      const device1 = DeviceFactory.create({ id: 1 });
+      const device2 = DeviceFactory.create({ id: 2 });
+      const software1 = SoftwareFactory.create({
+        deviceId: 1,
+        platform: "Android",
+      });
+      const software2 = SoftwareFactory.create({
+        deviceId: 2,
+        platform: "iOS",
+      });
+
+      const mockResults = [
+        { device: device1, software: software1 },
+        { device: device2, software: software2 },
+      ];
+      mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+      const result = await repository.findDevicesSupportingCombo({
+        comboId: 1,
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result[0].software[0].platform).toBe("Android");
+      expect(result[1].software[0].platform).toBe("iOS");
+    });
+  });
+});

--- a/packages/backend/tests/repositories/combo.repository.test.ts
+++ b/packages/backend/tests/repositories/combo.repository.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { ComboRepository } from "../../src/repositories/combo.repository";
 import { ComboFactory } from "../factories/combo.factory";
 import { BandFactory } from "../factories/band.factory";
-import { DeviceCapabilityFactory } from "../factories/device-capability.factory";
 import { DeviceFactory } from "../factories/device.factory";
 import { SoftwareFactory } from "../factories/software.factory";
 import { db } from "../../src/db/client";
@@ -45,8 +44,8 @@ describe("ComboRepository", () => {
       orderBy: vi.fn().mockReturnThis(),
     };
 
-    vi.mocked(db.select).mockReturnValue(mockSelect);
-    vi.mocked(db.selectDistinct).mockReturnValue(mockSelectDistinct);
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(mockSelect);
+    (db.selectDistinct as ReturnType<typeof vi.fn>).mockReturnValue(mockSelectDistinct);
   });
 
   afterEach(() => {
@@ -685,7 +684,7 @@ describe("ComboRepository", () => {
         providerId
       );
 
-      expect(result).toHaveLength(5);
+      expect(result).toHaveLength(3);
     });
 
     it("should handle different providers having different combos", async () => {

--- a/packages/backend/tests/repositories/device.repository.test.ts
+++ b/packages/backend/tests/repositories/device.repository.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { DeviceFactory } from "../factories/device.factory";
-import { db } from "../../src/db/client"
+import { db } from "../../src/db/client";
 import { DeviceRepository } from "../../src/repositories/device.repository";
 
 // Mock the database

--- a/packages/backend/tests/repositories/device.repository.test.ts
+++ b/packages/backend/tests/repositories/device.repository.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { DeviceFactory } from "../factories/device.factory";
+import { db } from "../../src/db/client"
+import { DeviceRepository } from "../../src/repositories/device.repository";
+
+// Mock the database
+vi.mock("../../src/db/client", () => ({
+  db: {
+    select: vi.fn(),
+  },
+}));
+
+describe("DeviceRepository", () => {
+  let repository: DeviceRepository;
+  let mockSelect: any;
+
+  beforeEach(() => {
+    DeviceFactory.reset();
+    repository = new DeviceRepository();
+
+    // Setup chainable mock
+    mockSelect = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      offset: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+    };
+
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(mockSelect);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("findById", () => {
+    it("should return device when found", async () => {
+      const mockDevice = DeviceFactory.create({ id: 1 });
+      mockSelect.limit.mockResolvedValue([mockDevice]);
+
+      const result = await repository.findById(1);
+
+      expect(result).toEqual(mockDevice);
+      expect(db.select).toHaveBeenCalled();
+    });
+
+    it("should return null when device not found", async () => {
+      mockSelect.limit.mockResolvedValue([]);
+
+      const result = await repository.findById(999);
+
+      expect(result).toBeNull();
+    });
+
+    it("should call database with correct parameters", async () => {
+      mockSelect.limit.mockResolvedValue([]);
+
+      await repository.findById(42);
+
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(mockSelect.limit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("findByIds", () => {
+    it("should return empty array when given empty array", async () => {
+      const result = await repository.findByIds([]);
+
+      expect(result).toEqual([]);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it("should return multiple devices for valid IDs", async () => {
+      const mockDevices = DeviceFactory.createMany(3);
+      mockSelect.where.mockResolvedValue(mockDevices);
+
+      const result = await repository.findByIds([1, 2, 3]);
+
+      expect(result).toEqual(mockDevices);
+      expect(result).toHaveLength(3);
+    });
+
+    it("should handle single ID in array", async () => {
+      const mockDevice = DeviceFactory.create({ id: 1 });
+      mockSelect.where.mockResolvedValue([mockDevice]);
+
+      const result = await repository.findByIds([1]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(mockDevice);
+    });
+  });
+
+  describe("search", () => {
+    it("should return all devices when no filters provided", async () => {
+      const mockDevices = DeviceFactory.createMany(5);
+      mockSelect.orderBy.mockResolvedValue(mockDevices);
+
+      const result = await repository.search({});
+
+      expect(result).toEqual(mockDevices);
+      expect(mockSelect.limit).toHaveBeenCalledWith(50); // default limit
+      expect(mockSelect.offset).toHaveBeenCalledWith(0); // default offset
+    });
+
+    it("should filter by vendor", async () => {
+      const appleDevice = DeviceFactory.createWithVendor("Apple");
+      mockSelect.orderBy.mockResolvedValue([appleDevice]);
+
+      const result = await repository.search({ vendor: "Apple" });
+
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+    });
+
+    it("should filter by model number", async () => {
+      const device = DeviceFactory.create({ modelNum: "SM-G991" });
+      mockSelect.orderBy.mockResolvedValue([device]);
+
+      const result = await repository.search({ modelNum: "SM-G991" });
+
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(result[0].modelNum).toBe("SM-G991");
+    });
+
+    it("should filter by market name", async () => {
+      const device = DeviceFactory.create({ marketName: "Galaxy S21" });
+      mockSelect.orderBy.mockResolvedValue([device]);
+
+      const result = await repository.search({ marketName: "Galaxy S21" });
+
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(result[0].marketName).toBe("Galaxy S21");
+    });
+
+    it("should filter by release date range", async () => {
+      const device = DeviceFactory.createWithDateRange(
+        "2023-01-01",
+        "2023-12-31"
+      );
+      mockSelect.orderBy.mockResolvedValue([device]);
+
+      const result = await repository.search({
+        releasedAfter: "2023-01-01",
+        releasedBefore: "2023-12-31",
+      });
+
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(result).toHaveLength(1);
+    });
+
+    it("should combine multiple filters", async () => {
+      const device = DeviceFactory.create({
+        vendor: "Samsung",
+        modelNum: "SM-G991",
+        releaseDate: "2023-06-15",
+      });
+      mockSelect.orderBy.mockResolvedValue([device]);
+
+      const result = await repository.search({
+        vendor: "Samsung",
+        modelNum: "SM-G991",
+        releasedAfter: "2023-01-01",
+      });
+
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(result[0].vendor).toBe("Samsung");
+    });
+
+    it("should respect custom limit and offset", async () => {
+      const mockDevices = DeviceFactory.createMany(10);
+      mockSelect.orderBy.mockResolvedValue(mockDevices);
+
+      await repository.search({ limit: 10, offset: 20 });
+
+      expect(mockSelect.limit).toHaveBeenCalledWith(10);
+      expect(mockSelect.offset).toHaveBeenCalledWith(20);
+    });
+
+    it("should handle partial text matches in vendor", async () => {
+      const samsungDevice = DeviceFactory.createWithVendor(
+        "Samsung Electronics"
+      );
+      mockSelect.orderBy.mockResolvedValue([samsungDevice]);
+
+      const result = await repository.search({ vendor: "Samsung" });
+
+      expect(result[0].vendor).toContain("Samsung");
+    });
+
+    it("should handle special characters in search strings", async () => {
+      const device = DeviceFactory.create({ modelNum: "SM-G991/DS" });
+      mockSelect.orderBy.mockResolvedValue([device]);
+
+      const result = await repository.search({ modelNum: "SM-G991/DS" });
+
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe("findAll", () => {
+    it("should return all devices ordered by vendor and model", async () => {
+      const mockDevices = [
+        DeviceFactory.create({ vendor: "Apple", modelNum: "A001" }),
+        DeviceFactory.create({ vendor: "Samsung", modelNum: "S001" }),
+      ];
+      mockSelect.orderBy.mockResolvedValue(mockDevices);
+
+      const result = await repository.findAll();
+
+      expect(result).toEqual(mockDevices);
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+
+    it("should return empty array when no devices exist", async () => {
+      mockSelect.orderBy.mockResolvedValue([]);
+
+      const result = await repository.findAll();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("count", () => {
+    it("should return total device count", async () => {
+      mockSelect.from.mockResolvedValue([{ count: 42 }]);
+
+      const result = await repository.count();
+
+      expect(result).toBe(42);
+    });
+
+    it("should return 0 when no devices exist", async () => {
+      mockSelect.from.mockResolvedValue([{ count: 0 }]);
+
+      const result = await repository.count();
+
+      expect(result).toBe(0);
+    });
+
+    it("should handle string count values from database", async () => {
+      mockSelect.from.mockResolvedValue([{ count: "123" }]);
+
+      const result = await repository.count();
+
+      expect(result).toBe(123);
+      expect(typeof result).toBe("number");
+    });
+  });
+});

--- a/packages/backend/tests/repositories/feature.repository.test.ts
+++ b/packages/backend/tests/repositories/feature.repository.test.ts
@@ -1,0 +1,614 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { FeatureRepository } from "../../src/repositories/feature.repository";
+import { FeatureFactory } from "../factories/feature.factory";
+import { DeviceFactory } from "../factories/device.factory";
+import { SoftwareFactory } from "../factories/software.factory";
+import { db } from "../../src/db/client";
+
+// Mock the database
+vi.mock("../../src/db/client", () => ({
+  db: {
+    select: vi.fn(),
+    selectDistinct: vi.fn(),
+  },
+}));
+
+describe("FeatureRepository", () => {
+  let repository: FeatureRepository;
+  let mockSelect: any;
+  let mockSelectDistinct: any;
+
+  beforeEach(() => {
+    FeatureFactory.reset();
+    DeviceFactory.reset();
+    SoftwareFactory.reset();
+    repository = new FeatureRepository();
+
+    // Setup chainable mocks for regular select
+    mockSelect = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+    };
+
+    // Setup chainable mocks for selectDistinct
+    mockSelectDistinct = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      innerJoin: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+      then: vi.fn().mockReturnThis(),
+    };
+
+    vi.mocked(db.select).mockReturnValue(mockSelect);
+    vi.mocked(db.selectDistinct).mockReturnValue(mockSelectDistinct);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("findById", () => {
+    it("should return feature when found", async () => {
+      const mockFeature = FeatureFactory.create({ id: 1 });
+      mockSelect.limit.mockResolvedValue([mockFeature]);
+
+      const result = await repository.findById(1);
+
+      expect(result).toEqual(mockFeature);
+      expect(db.select).toHaveBeenCalled();
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(mockSelect.limit).toHaveBeenCalledWith(1);
+    });
+
+    it("should return null when feature not found", async () => {
+      mockSelect.limit.mockResolvedValue([]);
+
+      const result = await repository.findById(999);
+
+      expect(result).toBeNull();
+    });
+
+    it("should handle valid ID parameter", async () => {
+      mockSelect.limit.mockResolvedValue([]);
+
+      await repository.findById(42);
+
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(mockSelect.limit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("findByIds", () => {
+    it("should return empty array when given empty array", async () => {
+      const result = await repository.findByIds([]);
+
+      expect(result).toEqual([]);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it("should return multiple features for valid IDs", async () => {
+      const mockFeatures = FeatureFactory.createMany(3);
+      mockSelect.where.mockResolvedValue(mockFeatures);
+
+      const result = await repository.findByIds([1, 2, 3]);
+
+      expect(result).toEqual(mockFeatures);
+      expect(result).toHaveLength(3);
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should handle single ID in array", async () => {
+      const mockFeature = FeatureFactory.create({ id: 1 });
+      mockSelect.where.mockResolvedValue([mockFeature]);
+
+      const result = await repository.findByIds([1]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(mockFeature);
+    });
+
+    it("should handle large array of IDs", async () => {
+      const ids = Array.from({ length: 100 }, (_, i) => i + 1);
+      const mockFeatures = FeatureFactory.createMany(100);
+      mockSelect.where.mockResolvedValue(mockFeatures);
+
+      const result = await repository.findByIds(ids);
+
+      expect(result).toHaveLength(100);
+    });
+  });
+
+  describe("search", () => {
+    it("should return all features when no filters provided", async () => {
+      const mockFeatures = FeatureFactory.createMany(5);
+      mockSelect.orderBy.mockResolvedValue(mockFeatures);
+
+      const result = await repository.search();
+
+      expect(result).toEqual(mockFeatures);
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+
+    it("should filter by name using LIKE", async () => {
+      const feature = FeatureFactory.createWithName("VoLTE");
+      mockSelect.orderBy.mockResolvedValue([feature]);
+
+      const result = await repository.search({ name: "VoLTE" });
+
+      expect(result[0].name).toBe("VoLTE");
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should handle partial name matches", async () => {
+      const features = [
+        FeatureFactory.createWithName("VoLTE"),
+        FeatureFactory.createWithName("VoNR"),
+      ];
+      mockSelect.orderBy.mockResolvedValue(features);
+
+      const result = await repository.search({ name: "Vo" });
+
+      expect(result).toHaveLength(2);
+      expect(result.every((f) => f.name.includes("Vo"))).toBe(true);
+    });
+
+    it("should return empty array when no features match filter", async () => {
+      mockSelect.orderBy.mockResolvedValue([]);
+
+      const result = await repository.search({ name: "NonExistentFeature" });
+
+      expect(result).toEqual([]);
+    });
+
+    it("should order results by name", async () => {
+      const mockFeatures = FeatureFactory.createMany(5);
+      mockSelect.orderBy.mockResolvedValue(mockFeatures);
+
+      await repository.search();
+
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+
+    it("should handle empty filter object", async () => {
+      const mockFeatures = FeatureFactory.createMany(3);
+      mockSelect.orderBy.mockResolvedValue(mockFeatures);
+
+      const result = await repository.search({});
+
+      expect(result).toEqual(mockFeatures);
+    });
+
+    it("should handle case-sensitive searches", async () => {
+      const feature = FeatureFactory.createWithName("VoLTE");
+      mockSelect.orderBy.mockResolvedValue([feature]);
+
+      const result = await repository.search({ name: "volte" });
+
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+  });
+
+  describe("findAll", () => {
+    it("should return all features ordered by name", async () => {
+      const mockFeatures = [
+        FeatureFactory.createWithName("eSIM"),
+        FeatureFactory.createWithName("VoLTE"),
+        FeatureFactory.createWithName("Wi-Fi Calling"),
+      ];
+      mockSelect.orderBy.mockResolvedValue(mockFeatures);
+
+      const result = await repository.findAll();
+
+      expect(result).toEqual(mockFeatures);
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+
+    it("should return empty array when no features exist", async () => {
+      mockSelect.orderBy.mockResolvedValue([]);
+
+      const result = await repository.findAll();
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle large number of features", async () => {
+      const mockFeatures = FeatureFactory.createMany(100);
+      mockSelect.orderBy.mockResolvedValue(mockFeatures);
+
+      const result = await repository.findAll();
+
+      expect(result).toHaveLength(100);
+    });
+  });
+
+  describe("findDevicesSupportingFeature", () => {
+    const featureId = 1;
+
+    describe("global feature queries (no providerId)", () => {
+      it("should return devices supporting a feature globally", async () => {
+        const device1 = DeviceFactory.create({ id: 1 });
+        const device2 = DeviceFactory.create({ id: 2 });
+        const software1 = SoftwareFactory.create({ deviceId: 1 });
+        const software2 = SoftwareFactory.create({ deviceId: 2 });
+
+        const mockResults = [
+          { device: device1, software: software1, providerId: 1 },
+          { device: device1, software: software1, providerId: 2 },
+          { device: device2, software: software2, providerId: 1 },
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingFeature({
+          featureId,
+        });
+
+        expect(result).toHaveLength(2);
+        expect(result[0].supportStatus).toBe("global");
+        expect(result[0].provider).toBeNull();
+        expect(result[0].device.id).toBe(1);
+        expect(result[1].device.id).toBe(2);
+      });
+
+      it("should group software by device for global query", async () => {
+        const device = DeviceFactory.create({ id: 1 });
+        const software1 = SoftwareFactory.create({ id: 1, deviceId: 1 });
+        const software2 = SoftwareFactory.create({ id: 2, deviceId: 1 });
+
+        const mockResults = [
+          { device, software: software1, providerId: 1 },
+          { device, software: software2, providerId: 1 },
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingFeature({
+          featureId,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].software).toHaveLength(2);
+        expect(result[0].software[0].id).toBe(1);
+        expect(result[0].software[1].id).toBe(2);
+      });
+
+      it("should deduplicate software entries for same device", async () => {
+        const device = DeviceFactory.create({ id: 1 });
+        const software = SoftwareFactory.create({ id: 1, deviceId: 1 });
+
+        // Simulating duplicate rows from multiple providers
+        const mockResults = [
+          { device, software, providerId: 1 },
+          { device, software, providerId: 2 },
+          { device, software, providerId: 3 },
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingFeature({
+          featureId,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].software).toHaveLength(1);
+      });
+
+      it("should return empty array when no devices support the feature", async () => {
+        mockSelectDistinct.orderBy.mockResolvedValue([]);
+
+        const result = await repository.findDevicesSupportingFeature({
+          featureId,
+        });
+
+        expect(result).toEqual([]);
+      });
+
+      it("should handle multiple devices with varying software counts", async () => {
+        const device1 = DeviceFactory.create({ id: 1 });
+        const device2 = DeviceFactory.create({ id: 2 });
+        const software1 = SoftwareFactory.create({ id: 1, deviceId: 1 });
+        const software2 = SoftwareFactory.create({ id: 2, deviceId: 1 });
+        const software3 = SoftwareFactory.create({ id: 3, deviceId: 2 });
+
+        const mockResults = [
+          { device: device1, software: software1, providerId: 1 },
+          { device: device1, software: software2, providerId: 1 },
+          { device: device2, software: software3, providerId: 1 },
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingFeature({
+          featureId,
+        });
+
+        expect(result).toHaveLength(2);
+        expect(result[0].software).toHaveLength(2);
+        expect(result[1].software).toHaveLength(1);
+      });
+    });
+
+    describe("provider-specific feature queries", () => {
+      const providerId = 10;
+
+      it("should return devices supporting a feature for specific provider", async () => {
+        const device1 = DeviceFactory.create({ id: 1 });
+        const device2 = DeviceFactory.create({ id: 2 });
+        const software1 = SoftwareFactory.create({ deviceId: 1 });
+        const software2 = SoftwareFactory.create({ deviceId: 2 });
+
+        const mockResults = [
+          { device: device1, software: software1, providerId },
+          { device: device2, software: software2, providerId },
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingFeature({
+          featureId,
+          providerId,
+        });
+
+        expect(result).toHaveLength(2);
+        expect(result[0].supportStatus).toBe("provider-specific");
+        expect(result[0].provider).toEqual({ providerId });
+        expect(result[1].provider).toEqual({ providerId });
+      });
+
+      it("should group software by device for provider-specific query", async () => {
+        const device = DeviceFactory.create({ id: 1 });
+        const software1 = SoftwareFactory.create({ id: 1, deviceId: 1 });
+        const software2 = SoftwareFactory.create({ id: 2, deviceId: 1 });
+
+        const mockResults = [
+          { device, software: software1, providerId },
+          { device, software: software2, providerId },
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingFeature({
+          featureId,
+          providerId,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].software).toHaveLength(2);
+      });
+
+      it("should deduplicate software for provider-specific query", async () => {
+        const device = DeviceFactory.create({ id: 1 });
+        const software = SoftwareFactory.create({ id: 1, deviceId: 1 });
+
+        const mockResults = [
+          { device, software, providerId },
+          { device, software, providerId }, // duplicate
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingFeature({
+          featureId,
+          providerId,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].software).toHaveLength(1);
+      });
+
+      it("should return empty array when no devices match provider criteria", async () => {
+        mockSelectDistinct.orderBy.mockResolvedValue([]);
+
+        const result = await repository.findDevicesSupportingFeature({
+          featureId,
+          providerId,
+        });
+
+        expect(result).toEqual([]);
+      });
+
+      it("should only include devices for the specified provider", async () => {
+        const device1 = DeviceFactory.create({ id: 1 });
+        const device2 = DeviceFactory.create({ id: 2 });
+        const software1 = SoftwareFactory.create({ deviceId: 1 });
+        const software2 = SoftwareFactory.create({ deviceId: 2 });
+
+        // Only device1 supports feature on provider 10
+        const mockResults = [
+          { device: device1, software: software1, providerId: 10 },
+        ];
+        mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+        const result = await repository.findDevicesSupportingFeature({
+          featureId,
+          providerId: 10,
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].device.id).toBe(1);
+      });
+    });
+  });
+
+  describe("findByDeviceSoftwareProvider", () => {
+    const deviceId = 1;
+    const softwareId = 1;
+
+    it("should return features for device/software without provider filter", async () => {
+      const features = FeatureFactory.createMany(3);
+      const mockResults = features.map((feature) => ({ feature }));
+      mockSelectDistinct.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelectDistinct.where.mockResolvedValue(mockSelectDistinct);
+
+      const result = await repository.findByDeviceSoftwareProvider(
+        deviceId,
+        softwareId
+      );
+
+      expect(result).toEqual(features);
+      expect(mockSelectDistinct.innerJoin).toHaveBeenCalled();
+      expect(mockSelectDistinct.where).toHaveBeenCalled();
+    });
+
+    it("should filter by provider when provided", async () => {
+      const features = FeatureFactory.createMany(2);
+      const mockResults = features.map((feature) => ({ feature }));
+      mockSelectDistinct.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelectDistinct.where.mockResolvedValue(mockSelectDistinct);
+
+      const result = await repository.findByDeviceSoftwareProvider(
+        deviceId,
+        softwareId,
+        10
+      );
+
+      expect(result).toEqual(features);
+      expect(mockSelectDistinct.where).toHaveBeenCalled();
+    });
+
+    it("should return empty array when no features found", async () => {
+      mockSelectDistinct.then.mockImplementation((fn: any) => fn([]));
+      mockSelectDistinct.where.mockResolvedValue(mockSelectDistinct);
+
+      const result = await repository.findByDeviceSoftwareProvider(
+        deviceId,
+        softwareId
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it("should return distinct features only", async () => {
+      const feature = FeatureFactory.create({ id: 1, name: "VoLTE" });
+      const mockResults = [{ feature }, { feature }]; // duplicate
+      mockSelectDistinct.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelectDistinct.where.mockResolvedValue(mockSelectDistinct);
+
+      const result = await repository.findByDeviceSoftwareProvider(
+        deviceId,
+        softwareId
+      );
+
+      expect(result).toHaveLength(2); // selectDistinct should handle this
+    });
+
+    it("should handle device/software with many features", async () => {
+      const features = FeatureFactory.createMany(15);
+      const mockResults = features.map((feature) => ({ feature }));
+      mockSelectDistinct.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelectDistinct.where.mockResolvedValue(mockSelectDistinct);
+
+      const result = await repository.findByDeviceSoftwareProvider(
+        deviceId,
+        softwareId
+      );
+
+      expect(result).toHaveLength(15);
+    });
+
+    it("should differentiate features by provider", async () => {
+      const voiceFeatures = FeatureFactory.createVoiceFeatures();
+      const mockResults = voiceFeatures.map((feature) => ({ feature }));
+      mockSelectDistinct.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelectDistinct.where.mockResolvedValue(mockSelectDistinct);
+
+      const result = await repository.findByDeviceSoftwareProvider(
+        deviceId,
+        softwareId,
+        10
+      );
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(mockSelectDistinct.where).toHaveBeenCalled();
+    });
+
+    it("should handle optional providerId parameter", async () => {
+      const features = FeatureFactory.createMany(3);
+      const mockResults = features.map((feature) => ({ feature }));
+      mockSelectDistinct.then.mockImplementation((fn: any) => fn(mockResults));
+      mockSelectDistinct.where.mockResolvedValue(mockSelectDistinct);
+
+      const result = await repository.findByDeviceSoftwareProvider(
+        deviceId,
+        softwareId,
+        undefined
+      );
+
+      expect(result).toEqual(features);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle features with special characters in name", async () => {
+      const feature = FeatureFactory.create({ name: "Wi-Fi Calling (VoWiFi)" });
+      mockSelect.limit.mockResolvedValue([feature]);
+
+      const result = await repository.findById(1);
+
+      expect(result?.name).toBe("Wi-Fi Calling (VoWiFi)");
+    });
+
+    it("should handle features with numbers in name", async () => {
+      const feature = FeatureFactory.create({ name: "256 QAM" });
+      mockSelect.limit.mockResolvedValue([feature]);
+
+      const result = await repository.findById(1);
+
+      expect(result?.name).toBe("256 QAM");
+    });
+
+    it("should handle very long feature names", async () => {
+      const longName =
+        "Enhanced Multi-User Multiple Input Multiple Output with Beamforming";
+      const feature = FeatureFactory.create({ name: longName });
+      mockSelect.limit.mockResolvedValue([feature]);
+
+      const result = await repository.findById(1);
+
+      expect(result?.name).toBe(longName);
+    });
+
+    it("should handle features with acronyms", async () => {
+      const features = [
+        FeatureFactory.create({ name: "HPUE" }),
+        FeatureFactory.create({ name: "LAA" }),
+        FeatureFactory.create({ name: "NR-DC" }),
+      ];
+      mockSelect.where.mockResolvedValue(features);
+
+      const result = await repository.findByIds([1, 2, 3]);
+
+      expect(result).toHaveLength(3);
+    });
+
+    it("should handle very large result sets for findDevicesSupportingFeature", async () => {
+      const devices = Array.from({ length: 100 }, (_, i) => {
+        const device = DeviceFactory.create({ id: i + 1 });
+        const software = SoftwareFactory.create({ deviceId: i + 1 });
+        return { device, software, providerId: 1 };
+      });
+      mockSelectDistinct.orderBy.mockResolvedValue(devices);
+
+      const result = await repository.findDevicesSupportingFeature({
+        featureId: 1,
+      });
+
+      expect(result).toHaveLength(100);
+    });
+
+    it("should handle cross-provider feature support correctly", async () => {
+      const device = DeviceFactory.create({ id: 1 });
+      const software = SoftwareFactory.create({ deviceId: 1 });
+
+      // Device supports feature on multiple providers
+      const mockResults = [
+        { device, software, providerId: 1 },
+        { device, software, providerId: 2 },
+        { device, software, providerId: 3 },
+      ];
+      mockSelectDistinct.orderBy.mockResolvedValue(mockResults);
+
+      const resultGlobal = await repository.findDevicesSupportingFeature({
+        featureId: 1,
+      });
+
+      expect(resultGlobal).toHaveLength(1);
+      expect(resultGlobal[0].supportStatus).toBe("global");
+    });
+  });
+});

--- a/packages/backend/tests/repositories/feature.repository.test.ts
+++ b/packages/backend/tests/repositories/feature.repository.test.ts
@@ -41,8 +41,8 @@ describe("FeatureRepository", () => {
       then: vi.fn().mockReturnThis(),
     };
 
-    vi.mocked(db.select).mockReturnValue(mockSelect);
-    vi.mocked(db.selectDistinct).mockReturnValue(mockSelectDistinct);
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(mockSelect);
+    (db.selectDistinct as ReturnType<typeof vi.fn>).mockReturnValue(mockSelectDistinct);
   });
 
   afterEach(() => {
@@ -186,7 +186,7 @@ describe("FeatureRepository", () => {
 
       const result = await repository.search({ name: "volte" });
 
-      expect(mockSelect.where).toHaveBeenCalled();
+      expect(result).toEqual([feature]);
     });
   });
 
@@ -404,9 +404,7 @@ describe("FeatureRepository", () => {
 
       it("should only include devices for the specified provider", async () => {
         const device1 = DeviceFactory.create({ id: 1 });
-        const device2 = DeviceFactory.create({ id: 2 });
         const software1 = SoftwareFactory.create({ deviceId: 1 });
-        const software2 = SoftwareFactory.create({ deviceId: 2 });
 
         // Only device1 supports feature on provider 10
         const mockResults = [

--- a/packages/backend/tests/repositories/provider.repository.test.ts
+++ b/packages/backend/tests/repositories/provider.repository.test.ts
@@ -26,7 +26,7 @@ describe("ProviderRepository", () => {
       orderBy: vi.fn().mockReturnThis(),
     };
 
-    vi.mocked(db.select).mockReturnValue(mockSelect);
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(mockSelect);
   });
 
   afterEach(() => {
@@ -72,8 +72,6 @@ describe("ProviderRepository", () => {
       expect(result).toBeDefined();
       expect(result?.id).toBe(mockProvider.id);
       expect(result?.name).toBe("Verizon");
-      expect(result?.createdAt).toBeDefined();
-      expect(result?.updatedAt).toBeDefined();
     });
   });
 

--- a/packages/backend/tests/repositories/provider.repository.test.ts
+++ b/packages/backend/tests/repositories/provider.repository.test.ts
@@ -1,0 +1,454 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { ProviderRepository } from "../../src/repositories/provider.repository";
+import { ProviderFactory } from "../factories/provider.factory";
+import { db } from "../../src/db/client";
+
+// Mock the database
+vi.mock("../../src/db/client", () => ({
+  db: {
+    select: vi.fn(),
+  },
+}));
+
+describe("ProviderRepository", () => {
+  let repository: ProviderRepository;
+  let mockSelect: any;
+
+  beforeEach(() => {
+    ProviderFactory.reset();
+    repository = new ProviderRepository();
+
+    // Setup chainable mock
+    mockSelect = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+    };
+
+    vi.mocked(db.select).mockReturnValue(mockSelect);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("findById", () => {
+    it("should return provider when found", async () => {
+      const mockProvider = ProviderFactory.create({ id: 1 });
+      mockSelect.limit.mockResolvedValue([mockProvider]);
+
+      const result = await repository.findById(1);
+
+      expect(result).toEqual(mockProvider);
+      expect(db.select).toHaveBeenCalled();
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(mockSelect.limit).toHaveBeenCalledWith(1);
+    });
+
+    it("should return null when provider not found", async () => {
+      mockSelect.limit.mockResolvedValue([]);
+
+      const result = await repository.findById(999);
+
+      expect(result).toBeNull();
+    });
+
+    it("should handle valid ID parameter", async () => {
+      mockSelect.limit.mockResolvedValue([]);
+
+      await repository.findById(42);
+
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(mockSelect.limit).toHaveBeenCalledWith(1);
+    });
+
+    it("should return provider with all fields populated", async () => {
+      const mockProvider = ProviderFactory.createWithName("Verizon");
+      mockSelect.limit.mockResolvedValue([mockProvider]);
+
+      const result = await repository.findById(1);
+
+      expect(result).toBeDefined();
+      expect(result?.id).toBe(mockProvider.id);
+      expect(result?.name).toBe("Verizon");
+      expect(result?.createdAt).toBeDefined();
+      expect(result?.updatedAt).toBeDefined();
+    });
+  });
+
+  describe("findByIds", () => {
+    it("should return empty array when given empty array", async () => {
+      const result = await repository.findByIds([]);
+
+      expect(result).toEqual([]);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it("should return multiple providers for valid IDs", async () => {
+      const mockProviders = ProviderFactory.createMajorUSCarriers();
+      mockSelect.where.mockResolvedValue(mockProviders);
+
+      const result = await repository.findByIds([1, 2, 3]);
+
+      expect(result).toEqual(mockProviders);
+      expect(result).toHaveLength(3);
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should handle single ID in array", async () => {
+      const mockProvider = ProviderFactory.create({ id: 1 });
+      mockSelect.where.mockResolvedValue([mockProvider]);
+
+      const result = await repository.findByIds([1]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(mockProvider);
+    });
+
+    it("should handle large array of IDs", async () => {
+      const ids = Array.from({ length: 100 }, (_, i) => i + 1);
+      const mockProviders = ProviderFactory.createMany(100);
+      mockSelect.where.mockResolvedValue(mockProviders);
+
+      const result = await repository.findByIds(ids);
+
+      expect(result).toHaveLength(100);
+    });
+
+    it("should return providers in any order from database", async () => {
+      const providers = [
+        ProviderFactory.createWithName("T-Mobile"),
+        ProviderFactory.createWithName("Verizon"),
+        ProviderFactory.createWithName("AT&T"),
+      ];
+      mockSelect.where.mockResolvedValue(providers);
+
+      const result = await repository.findByIds([1, 2, 3]);
+
+      expect(result).toHaveLength(3);
+      expect(result.map((p) => p.name)).toContain("Verizon");
+      expect(result.map((p) => p.name)).toContain("AT&T");
+      expect(result.map((p) => p.name)).toContain("T-Mobile");
+    });
+
+    it("should handle duplicate IDs gracefully", async () => {
+      const mockProviders = ProviderFactory.createMany(2);
+      mockSelect.where.mockResolvedValue(mockProviders);
+
+      const result = await repository.findByIds([1, 1, 2, 2]);
+
+      // Database should handle deduplication
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it("should work with major carrier IDs", async () => {
+      const majorCarriers = ProviderFactory.createMajorUSCarriers();
+      mockSelect.where.mockResolvedValue(majorCarriers);
+
+      const result = await repository.findByIds([1, 2, 3]);
+
+      expect(result.some((p) => p.name === "Verizon")).toBe(true);
+      expect(result.some((p) => p.name === "AT&T")).toBe(true);
+      expect(result.some((p) => p.name === "T-Mobile")).toBe(true);
+    });
+
+    it("should work with MVNO IDs", async () => {
+      const mvnos = ProviderFactory.createMVNOs();
+      mockSelect.where.mockResolvedValue(mvnos.slice(0, 3));
+
+      const result = await repository.findByIds([10, 11, 12]);
+
+      expect(result).toHaveLength(3);
+      expect(
+        result.every((p) =>
+          [
+            "Boost Mobile",
+            "Cricket Wireless",
+            "Metro by T-Mobile",
+            "Visible",
+            "Mint Mobile",
+            "Google Fi",
+          ].includes(p.name)
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe("findAll", () => {
+    it("should return all providers ordered by name", async () => {
+      const mockProviders = [
+        ProviderFactory.createWithName("AT&T"),
+        ProviderFactory.createWithName("T-Mobile"),
+        ProviderFactory.createWithName("Verizon"),
+      ];
+      mockSelect.orderBy.mockResolvedValue(mockProviders);
+
+      const result = await repository.findAll();
+
+      expect(result).toEqual(mockProviders);
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+
+    it("should return empty array when no providers exist", async () => {
+      mockSelect.orderBy.mockResolvedValue([]);
+
+      const result = await repository.findAll();
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle large number of providers", async () => {
+      const mockProviders = ProviderFactory.createMany(100);
+      mockSelect.orderBy.mockResolvedValue(mockProviders);
+
+      const result = await repository.findAll();
+
+      expect(result).toHaveLength(100);
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+
+    it("should include providers from different regions", async () => {
+      const usProviders = ProviderFactory.createUSProviders(3);
+      const canadianProviders = ProviderFactory.createCanadianProviders(3);
+      const allProviders = [...usProviders, ...canadianProviders];
+      mockSelect.orderBy.mockResolvedValue(allProviders);
+
+      const result = await repository.findAll();
+
+      expect(result).toHaveLength(6);
+      expect(
+        result.some((p) => ["Verizon", "AT&T", "T-Mobile"].includes(p.name))
+      ).toBe(true);
+      expect(
+        result.some((p) => ["Rogers", "Bell", "Telus"].includes(p.name))
+      ).toBe(true);
+    });
+
+    it("should include both major carriers and MVNOs", async () => {
+      const majorCarriers = ProviderFactory.createMajorUSCarriers();
+      const mvnos = ProviderFactory.createMVNOs();
+      const allProviders = [...majorCarriers, ...mvnos];
+      mockSelect.orderBy.mockResolvedValue(allProviders);
+
+      const result = await repository.findAll();
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+
+    it("should handle providers with special characters in names", async () => {
+      const providers = [
+        ProviderFactory.createWithName("AT&T"),
+        ProviderFactory.createWithName("Metro by T-Mobile"),
+        ProviderFactory.createWithName("O'Reilly Mobile"), // hypothetical
+      ];
+      mockSelect.orderBy.mockResolvedValue(providers);
+
+      const result = await repository.findAll();
+
+      expect(result).toHaveLength(3);
+      expect(result[0].name).toBe("AT&T");
+    });
+
+    it("should order alphabetically", async () => {
+      const providers = [
+        ProviderFactory.createWithName("Verizon"),
+        ProviderFactory.createWithName("AT&T"),
+        ProviderFactory.createWithName("T-Mobile"),
+      ];
+      // Assume DB returns them ordered
+      const orderedProviders = [providers[1], providers[2], providers[0]];
+      mockSelect.orderBy.mockResolvedValue(orderedProviders);
+
+      const result = await repository.findAll();
+
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+      // The mock returns pre-ordered results
+      expect(result[0].name).toBe("AT&T");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle providers with ampersands in name", async () => {
+      const provider = ProviderFactory.createWithName("AT&T");
+      mockSelect.limit.mockResolvedValue([provider]);
+
+      const result = await repository.findById(1);
+
+      expect(result?.name).toBe("AT&T");
+    });
+
+    it("should handle providers with spaces in name", async () => {
+      const provider = ProviderFactory.createWithName("US Cellular");
+      mockSelect.limit.mockResolvedValue([provider]);
+
+      const result = await repository.findById(1);
+
+      expect(result?.name).toBe("US Cellular");
+    });
+
+    it("should handle providers with hyphens in name", async () => {
+      const provider = ProviderFactory.createWithName("T-Mobile");
+      mockSelect.limit.mockResolvedValue([provider]);
+
+      const result = await repository.findById(1);
+
+      expect(result?.name).toBe("T-Mobile");
+    });
+
+    it("should handle providers with multiple words", async () => {
+      const provider = ProviderFactory.createWithName("Metro by T-Mobile");
+      mockSelect.limit.mockResolvedValue([provider]);
+
+      const result = await repository.findById(1);
+
+      expect(result?.name).toBe("Metro by T-Mobile");
+    });
+
+    it("should handle international provider names", async () => {
+      const providers = [
+        ProviderFactory.createWithName("NTT Docomo"),
+        ProviderFactory.createWithName("Deutsche Telekom"),
+        ProviderFactory.createWithName("Telefónica"),
+      ];
+      mockSelect.where.mockResolvedValue(providers);
+
+      const result = await repository.findByIds([1, 2, 3]);
+
+      expect(result).toHaveLength(3);
+    });
+
+    it("should handle providers with accented characters", async () => {
+      const provider = ProviderFactory.createWithName("Telefónica");
+      mockSelect.limit.mockResolvedValue([provider]);
+
+      const result = await repository.findById(1);
+
+      expect(result?.name).toBe("Telefónica");
+    });
+
+    it("should handle empty provider name edge case", async () => {
+      const provider = ProviderFactory.create({ name: "" });
+      mockSelect.limit.mockResolvedValue([provider]);
+
+      const result = await repository.findById(1);
+
+      expect(result).toBeDefined();
+      expect(result?.name).toBe("");
+    });
+
+    it("should handle very long provider names", async () => {
+      const longName =
+        "Very Long Provider Name With Many Words International Mobile Communications Corporation";
+      const provider = ProviderFactory.create({ name: longName });
+      mockSelect.limit.mockResolvedValue([provider]);
+
+      const result = await repository.findById(1);
+
+      expect(result?.name).toBe(longName);
+    });
+
+    it("should handle findByIds with sequential IDs", async () => {
+      const providers = ProviderFactory.createMany(10);
+      mockSelect.where.mockResolvedValue(providers);
+
+      const result = await repository.findByIds([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+      ]);
+
+      expect(result).toHaveLength(10);
+    });
+
+    it("should handle findByIds with non-sequential IDs", async () => {
+      const providers = [
+        ProviderFactory.create({ id: 1 }),
+        ProviderFactory.create({ id: 5 }),
+        ProviderFactory.create({ id: 10 }),
+        ProviderFactory.create({ id: 99 }),
+      ];
+      mockSelect.where.mockResolvedValue(providers);
+
+      const result = await repository.findByIds([1, 5, 10, 99]);
+
+      expect(result).toHaveLength(4);
+    });
+  });
+
+  describe("DataLoader compatibility", () => {
+    it("should work efficiently with DataLoader pattern for batch loading", async () => {
+      const providers = ProviderFactory.createMajorUSCarriers();
+      mockSelect.where.mockResolvedValue(providers);
+
+      // Simulate DataLoader batch
+      const ids = [1, 2, 3];
+      const result = await repository.findByIds(ids);
+
+      expect(result).toHaveLength(3);
+      expect(db.select).toHaveBeenCalledTimes(1); // Single query
+    });
+
+    it("should handle DataLoader with mixed existing and non-existing IDs", async () => {
+      const existingProviders = ProviderFactory.createMany(2);
+      mockSelect.where.mockResolvedValue(existingProviders);
+
+      // Request IDs where some don't exist
+      const result = await repository.findByIds([1, 2, 999]);
+
+      // Returns only existing providers
+      expect(result).toHaveLength(2);
+    });
+
+    it("should support batching many providers efficiently", async () => {
+      const manyProviders = ProviderFactory.createMany(50);
+      mockSelect.where.mockResolvedValue(manyProviders);
+
+      const ids = Array.from({ length: 50 }, (_, i) => i + 1);
+      const result = await repository.findByIds(ids);
+
+      expect(result).toHaveLength(50);
+      expect(db.select).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("real-world scenarios", () => {
+    it("should retrieve all US major carriers", async () => {
+      const majorCarriers = ProviderFactory.createMajorUSCarriers();
+      mockSelect.where.mockResolvedValue(majorCarriers);
+
+      const result = await repository.findByIds([1, 2, 3]);
+
+      expect(result.map((p) => p.name)).toEqual(
+        expect.arrayContaining(["Verizon", "AT&T", "T-Mobile"])
+      );
+    });
+
+    it("should retrieve Canadian carriers", async () => {
+      const canadianCarriers = ProviderFactory.createMajorCanadianCarriers();
+      mockSelect.where.mockResolvedValue(canadianCarriers);
+
+      const result = await repository.findByIds([10, 11, 12]);
+
+      expect(result.map((p) => p.name)).toEqual(
+        expect.arrayContaining(["Rogers", "Bell", "Telus"])
+      );
+    });
+
+    it("should handle mixed major carriers and MVNOs", async () => {
+      const providers = [
+        ProviderFactory.createWithName("Verizon"),
+        ProviderFactory.createWithName("Visible"), // MVNO on Verizon
+        ProviderFactory.createWithName("AT&T"),
+        ProviderFactory.createWithName("Cricket Wireless"), // MVNO on AT&T
+      ];
+      mockSelect.where.mockResolvedValue(providers);
+
+      const result = await repository.findByIds([1, 2, 3, 4]);
+
+      expect(result).toHaveLength(4);
+      expect(result.some((p) => p.name === "Verizon")).toBe(true);
+      expect(result.some((p) => p.name === "Visible")).toBe(true);
+    });
+  });
+});

--- a/packages/backend/tests/repositories/software.repository.test.ts
+++ b/packages/backend/tests/repositories/software.repository.test.ts
@@ -26,7 +26,7 @@ describe("SoftwareRepository", () => {
       orderBy: vi.fn().mockReturnThis(),
     };
 
-    vi.mocked(db.select).mockReturnValue(mockSelect);
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue(mockSelect);
   });
 
   afterEach(() => {
@@ -283,7 +283,6 @@ describe("SoftwareRepository", () => {
     it("should handle software with null or undefined fields gracefully", async () => {
       const mockSoftware = SoftwareFactory.create({
         platform: "Android",
-        version: "1.0",
       });
       mockSelect.limit.mockResolvedValue([mockSoftware]);
 

--- a/packages/backend/tests/repositories/software.repository.test.ts
+++ b/packages/backend/tests/repositories/software.repository.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { SoftwareRepository } from "../../src/repositories/software.repository";
+import { SoftwareFactory } from "../factories/software.factory";
+import { db } from "../../src/db/client";
+
+// Mock the database
+vi.mock("../../src/db/client", () => ({
+  db: {
+    select: vi.fn(),
+  },
+}));
+
+describe("SoftwareRepository", () => {
+  let repository: SoftwareRepository;
+  let mockSelect: any;
+
+  beforeEach(() => {
+    SoftwareFactory.reset();
+    repository = new SoftwareRepository();
+
+    // Setup chainable mock
+    mockSelect = {
+      from: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      orderBy: vi.fn().mockReturnThis(),
+    };
+
+    vi.mocked(db.select).mockReturnValue(mockSelect);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("findById", () => {
+    it("should return software when found", async () => {
+      const mockSoftware = SoftwareFactory.create({ id: 1 });
+      mockSelect.limit.mockResolvedValue([mockSoftware]);
+
+      const result = await repository.findById(1);
+
+      expect(result).toEqual(mockSoftware);
+      expect(db.select).toHaveBeenCalled();
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(mockSelect.limit).toHaveBeenCalledWith(1);
+    });
+
+    it("should return null when software not found", async () => {
+      mockSelect.limit.mockResolvedValue([]);
+
+      const result = await repository.findById(999);
+
+      expect(result).toBeNull();
+    });
+
+    it("should handle valid ID parameter", async () => {
+      mockSelect.limit.mockResolvedValue([]);
+
+      await repository.findById(42);
+
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(mockSelect.limit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("findByIds", () => {
+    it("should return empty array when given empty array", async () => {
+      const result = await repository.findByIds([]);
+
+      expect(result).toEqual([]);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it("should return multiple software entries for valid IDs", async () => {
+      const mockSoftware = SoftwareFactory.createMany(3);
+      mockSelect.where.mockResolvedValue(mockSoftware);
+
+      const result = await repository.findByIds([1, 2, 3]);
+
+      expect(result).toEqual(mockSoftware);
+      expect(result).toHaveLength(3);
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should handle single ID in array", async () => {
+      const mockSoftware = SoftwareFactory.create({ id: 1 });
+      mockSelect.where.mockResolvedValue([mockSoftware]);
+
+      const result = await repository.findByIds([1]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(mockSoftware);
+    });
+
+    it("should handle large array of IDs", async () => {
+      const ids = Array.from({ length: 100 }, (_, i) => i + 1);
+      const mockSoftware = SoftwareFactory.createMany(100);
+      mockSelect.where.mockResolvedValue(mockSoftware);
+
+      const result = await repository.findByIds(ids);
+
+      expect(result).toHaveLength(100);
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+  });
+
+  describe("findByDevice", () => {
+    const deviceId = 1;
+
+    it("should return all software for a device with no filters", async () => {
+      const mockSoftware = SoftwareFactory.createManyForDevice(deviceId, 3);
+      mockSelect.orderBy.mockResolvedValue(mockSoftware);
+
+      const result = await repository.findByDevice(deviceId);
+
+      expect(result).toEqual(mockSoftware);
+      expect(result.every((s) => s.deviceId === deviceId)).toBe(true);
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+
+    it("should filter by platform", async () => {
+      const mockSoftware = [
+        SoftwareFactory.createForDevice(deviceId, { platform: "Android" }),
+      ];
+      mockSelect.orderBy.mockResolvedValue(mockSoftware);
+
+      const result = await repository.findByDevice(deviceId, {
+        platform: "Android",
+      });
+
+      expect(result[0].platform).toBe("Android");
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should filter by release date", async () => {
+      const mockSoftware = [
+        SoftwareFactory.createForDevice(deviceId, {
+          releaseDate: "2024-06-01",
+        }),
+      ];
+      mockSelect.orderBy.mockResolvedValue(mockSoftware);
+
+      const result = await repository.findByDevice(deviceId, {
+        releasedAfter: "2024-01-01",
+      });
+
+      expect(result[0].releaseDate).toBe("2024-06-01");
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should combine platform and date filters", async () => {
+      const mockSoftware = [
+        SoftwareFactory.createForDevice(deviceId, {
+          platform: "iOS",
+          releaseDate: "2024-06-01",
+        }),
+      ];
+      mockSelect.orderBy.mockResolvedValue(mockSoftware);
+
+      const result = await repository.findByDevice(deviceId, {
+        platform: "iOS",
+        releasedAfter: "2024-01-01",
+      });
+
+      expect(result[0].platform).toBe("iOS");
+      expect(result[0].releaseDate).toBe("2024-06-01");
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should return empty array when no software matches filters", async () => {
+      mockSelect.orderBy.mockResolvedValue([]);
+
+      const result = await repository.findByDevice(deviceId, {
+        platform: "NonExistentPlatform",
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it("should order results by release date", async () => {
+      const mockSoftware = SoftwareFactory.createVersionHistory(deviceId, [
+        "1.0",
+        "2.0",
+        "3.0",
+      ]);
+      mockSelect.orderBy.mockResolvedValue(mockSoftware);
+
+      await repository.findByDevice(deviceId);
+
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+
+    it("should handle edge case with undefined filters", async () => {
+      const mockSoftware = SoftwareFactory.createManyForDevice(deviceId, 2);
+      mockSelect.orderBy.mockResolvedValue(mockSoftware);
+
+      const result = await repository.findByDevice(deviceId, undefined);
+
+      expect(result).toEqual(mockSoftware);
+    });
+  });
+
+  describe("findByDevices", () => {
+    it("should return empty array when given empty array", async () => {
+      const result = await repository.findByDevices([]);
+
+      expect(result).toEqual([]);
+      expect(db.select).not.toHaveBeenCalled();
+    });
+
+    it("should return software for multiple devices", async () => {
+      const deviceIds = [1, 2, 3];
+      const mockSoftware = SoftwareFactory.createForDevices(deviceIds);
+      mockSelect.orderBy.mockResolvedValue(mockSoftware);
+
+      const result = await repository.findByDevices(deviceIds);
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(mockSelect.where).toHaveBeenCalled();
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+
+    it("should return software for single device in array", async () => {
+      const deviceId = 1;
+      const mockSoftware = SoftwareFactory.createManyForDevice(deviceId, 2);
+      mockSelect.orderBy.mockResolvedValue(mockSoftware);
+
+      const result = await repository.findByDevices([deviceId]);
+
+      expect(result.every((s) => s.deviceId === deviceId)).toBe(true);
+    });
+
+    it("should handle large batch of device IDs", async () => {
+      const deviceIds = Array.from({ length: 50 }, (_, i) => i + 1);
+      const mockSoftware = deviceIds.flatMap((id) =>
+        SoftwareFactory.createManyForDevice(id, 2)
+      );
+      mockSelect.orderBy.mockResolvedValue(mockSoftware);
+
+      const result = await repository.findByDevices(deviceIds);
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+
+    it("should order results by deviceId and releaseDate", async () => {
+      const deviceIds = [1, 2];
+      const mockSoftware = [
+        SoftwareFactory.createForDevice(1, { releaseDate: "2024-01-01" }),
+        SoftwareFactory.createForDevice(1, { releaseDate: "2024-06-01" }),
+        SoftwareFactory.createForDevice(2, { releaseDate: "2024-03-01" }),
+      ];
+      mockSelect.orderBy.mockResolvedValue(mockSoftware);
+
+      await repository.findByDevices(deviceIds);
+
+      expect(mockSelect.orderBy).toHaveBeenCalled();
+    });
+
+    it("should return empty array when no software exists for devices", async () => {
+      mockSelect.orderBy.mockResolvedValue([]);
+
+      const result = await repository.findByDevices([999, 1000]);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle duplicate device IDs gracefully", async () => {
+      const deviceIds = [1, 1, 2, 2];
+      const mockSoftware = SoftwareFactory.createForDevices([1, 2]);
+      mockSelect.orderBy.mockResolvedValue(mockSoftware);
+
+      const result = await repository.findByDevices(deviceIds);
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(mockSelect.where).toHaveBeenCalled();
+    });
+  });
+
+  describe("edge cases and error scenarios", () => {
+    it("should handle software with null or undefined fields gracefully", async () => {
+      const mockSoftware = SoftwareFactory.create({
+        platform: "Android",
+        version: "1.0",
+      });
+      mockSelect.limit.mockResolvedValue([mockSoftware]);
+
+      const result = await repository.findById(1);
+
+      expect(result).toBeDefined();
+      expect(result?.platform).toBe("Android");
+    });
+
+    it("should handle very old release dates", async () => {
+      const oldDate = "2010-01-01";
+      const mockSoftware = [
+        SoftwareFactory.createForDevice(1, { releaseDate: oldDate }),
+      ];
+      mockSelect.orderBy.mockResolvedValue(mockSoftware);
+
+      const result = await repository.findByDevice(1, {
+        releasedAfter: "2009-01-01",
+      });
+
+      expect(result[0].releaseDate).toBe(oldDate);
+    });
+
+    it("should handle future release dates", async () => {
+      const futureDate = "2026-12-31";
+      const mockSoftware = [
+        SoftwareFactory.createForDevice(1, { releaseDate: futureDate }),
+      ];
+      mockSelect.orderBy.mockResolvedValue(mockSoftware);
+
+      const result = await repository.findByDevice(1);
+
+      expect(result[0].releaseDate).toBe(futureDate);
+    });
+  });
+});


### PR DESCRIPTION
## Description
Now with the graphQL implementation, we need a data access layer to aid with querying. This PR adds this.

## Approach Taken
Added the repo layer for various data models.

## What Could Go Wrong?
Given that this allows for querying of data, we need to ensure all of it is accurate.

## Remediation Strategy 
NA
