### PR TITLE
XMDEV-544: Fix date | string logic for query params

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,35 @@ db-migrate:
 .PHONY: db-seed
 db-seed:
 	cd packages/backend && bun run db:seed
+
+.PHONY: b-lint
+b-lint:
+	cd packages/backend && bun run lint
+
+.PHONY: b-lint-fix
+b-lint-fix:
+	cd packages/backend && bun run lint:fix
+
+.PHONY: b-types
+b-types:
+	cd packages/backend && bun run typecheck
+
+.PHONY: b-test
+b-test:
+	cd packages/backend && bun run test
+
+.PHONY: f-lint
+f-lint:
+	cd packages/frontend && bun run lint
+
+.PHONY: f-lint-fix
+f-lint-fix:
+	cd packages/frontend && bun run lint:fix
+
+.PHONY: f-types
+f-types:
+	cd packages/frontend && bun run typecheck
+
+.PHONY: f-test
+f-test:
+	cd packages/frontend && bun run test

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-.PHONY: start-frontend
-start-frontend:
+.PHONY: f-start
+f-start:
 	cd packages/frontend && bun run dev
 
-.PHONY: start-backend
-start-backend:
+.PHONY: b-start
+b-start:
 	cd packages/backend && bun run dev
 
 .PHONY: start-all

--- a/packages/backend/src/graphql/schema/builder.ts
+++ b/packages/backend/src/graphql/schema/builder.ts
@@ -11,7 +11,7 @@ export const builder = new SchemaBuilder<{
     };
     DateTime: {
       Output: Date | string;
-      Input: Date | string;
+      Input: Date;
     };
   };
 }>({

--- a/packages/backend/src/graphql/schema/queries/device.queries.ts
+++ b/packages/backend/src/graphql/schema/queries/device.queries.ts
@@ -63,16 +63,8 @@ builder.queryFields((t) => ({
         vendor: args.vendor || undefined,
         modelNum: args.modelNum || undefined,
         marketName: args.marketName || undefined,
-        releasedAfter: args.releasedAfter // XMDEV-544: Fix date casting
-          ? typeof args.releasedAfter === "string"
-            ? args.releasedAfter
-            : args.releasedAfter.toISOString()
-          : undefined,
-        releasedBefore: args.releasedBefore // XMDEV-544: Fix date casting
-          ? typeof args.releasedBefore === "string"
-            ? args.releasedBefore
-            : args.releasedBefore.toISOString()
-          : undefined,
+        releasedAfter: args.releasedAfter || undefined,
+        releasedBefore: args.releasedBefore || undefined,
         limit: args.limit ?? undefined,
         offset: args.offset ?? undefined,
       });

--- a/packages/backend/src/graphql/schema/types/device.ts
+++ b/packages/backend/src/graphql/schema/types/device.ts
@@ -42,10 +42,7 @@ DeviceType.implement({
         return ctx.loaders.softwareByDevice.load({
           deviceId: device.id,
           platform: args.platform || undefined,
-          releasedAfter:
-            args.releasedAfter instanceof Date
-              ? args.releasedAfter.toISOString()
-              : args.releasedAfter || undefined,
+          releasedAfter: args.releasedAfter || undefined,
         });
       },
     }),

--- a/packages/backend/src/repositories/device.repository.ts
+++ b/packages/backend/src/repositories/device.repository.ts
@@ -58,11 +58,11 @@ export class DeviceRepository {
     }
 
     if (releasedAfter) {
-      conditions.push(gte(device.releaseDate, releasedAfter)); // XMDEV-544: Fix date casting
+      conditions.push(gte(device.releaseDate, releasedAfter.toISOString()));
     }
 
     if (releasedBefore) {
-      conditions.push(lte(device.releaseDate, releasedBefore)); // XMDEV-544: Fix date casting
+      conditions.push(lte(device.releaseDate, releasedBefore.toISOString()));
     }
 
     if (conditions.length > 0) {

--- a/packages/backend/src/repositories/software.repository.ts
+++ b/packages/backend/src/repositories/software.repository.ts
@@ -32,7 +32,7 @@ export class SoftwareRepository {
     deviceId: number,
     filters?: {
       platform?: string;
-      releasedAfter?: string;
+      releasedAfter?: Date;
     }
   ) {
     const conditions = [eq(software.deviceId, deviceId)];
@@ -42,7 +42,9 @@ export class SoftwareRepository {
     }
 
     if (filters?.releasedAfter) {
-      conditions.push(gte(software.releaseDate, filters.releasedAfter));
+      conditions.push(
+        gte(software.releaseDate, filters.releasedAfter.toISOString())
+      );
     }
 
     return db

--- a/packages/backend/src/repositories/types.ts
+++ b/packages/backend/src/repositories/types.ts
@@ -9,8 +9,8 @@ export interface SearchDevicesParams extends PaginationParams {
   vendor?: string;
   modelNum?: string;
   marketName?: string;
-  releasedAfter?: string; // XMDEV-544: Fix date casting
-  releasedBefore?: string; // XMDEV-544: Fix date casting
+  releasedAfter?: Date;
+  releasedBefore?: Date;
 }
 
 export interface FindDevicesByBandParams {

--- a/packages/backend/tests/graphql/queries/device.queries.test.ts
+++ b/packages/backend/tests/graphql/queries/device.queries.test.ts
@@ -232,10 +232,7 @@ describe("Device GraphQL Queries", () => {
         vendor: undefined,
         modelNum: undefined,
         marketName: undefined,
-        releasedAfter:
-          typeof args.releasedAfter === "string"
-            ? args.releasedAfter
-            : args.releasedAfter?.toISOString(),
+        releasedAfter: args.releasedAfter,
         releasedBefore: undefined,
         limit: args.limit ?? undefined,
         offset: args.offset ?? undefined,
@@ -246,42 +243,7 @@ describe("Device GraphQL Queries", () => {
         vendor: undefined,
         modelNum: undefined,
         marketName: undefined,
-        releasedAfter: afterDate.toISOString(),
-        releasedBefore: undefined,
-        limit: 50,
-        offset: 0,
-      });
-    });
-
-    it("should filter by releasedAfter date when provided as string", async () => {
-      const dateString = "2023-01-01";
-      const mockDevices = DeviceFactory.createMany(3, {
-        releaseDate: "2023-06-15",
-      });
-      (deviceRepository.search as ReturnType<typeof vi.fn>).mockResolvedValue(
-        mockDevices
-      );
-
-      const args = { releasedAfter: dateString, limit: 50, offset: 0 };
-      const result = await deviceRepository.search({
-        vendor: undefined,
-        modelNum: undefined,
-        marketName: undefined,
-        releasedAfter:
-          typeof args.releasedAfter === "string"
-            ? args.releasedAfter
-            : undefined,
-        releasedBefore: undefined,
-        limit: args.limit ?? undefined,
-        offset: args.offset ?? undefined,
-      });
-
-      expect(result).toEqual(mockDevices);
-      expect(deviceRepository.search).toHaveBeenCalledWith({
-        vendor: undefined,
-        modelNum: undefined,
-        marketName: undefined,
-        releasedAfter: dateString,
+        releasedAfter: afterDate,
         releasedBefore: undefined,
         limit: 50,
         offset: 0,
@@ -303,10 +265,7 @@ describe("Device GraphQL Queries", () => {
         modelNum: undefined,
         marketName: undefined,
         releasedAfter: undefined,
-        releasedBefore:
-          typeof args.releasedBefore === "string"
-            ? args.releasedBefore
-            : args.releasedBefore?.toISOString(),
+        releasedBefore: args.releasedBefore,
         limit: args.limit ?? undefined,
         offset: args.offset ?? undefined,
       });
@@ -317,42 +276,7 @@ describe("Device GraphQL Queries", () => {
         modelNum: undefined,
         marketName: undefined,
         releasedAfter: undefined,
-        releasedBefore: beforeDate.toISOString(),
-        limit: 50,
-        offset: 0,
-      });
-    });
-
-    it("should filter by releasedBefore date when provided as string", async () => {
-      const dateString = "2023-12-31";
-      const mockDevices = DeviceFactory.createMany(3, {
-        releaseDate: "2023-06-15",
-      });
-      (deviceRepository.search as ReturnType<typeof vi.fn>).mockResolvedValue(
-        mockDevices
-      );
-
-      const args = { releasedBefore: dateString, limit: 50, offset: 0 };
-      const result = await deviceRepository.search({
-        vendor: undefined,
-        modelNum: undefined,
-        marketName: undefined,
-        releasedAfter: undefined,
-        releasedBefore:
-          typeof args.releasedBefore === "string"
-            ? args.releasedBefore
-            : undefined,
-        limit: args.limit ?? undefined,
-        offset: args.offset ?? undefined,
-      });
-
-      expect(result).toEqual(mockDevices);
-      expect(deviceRepository.search).toHaveBeenCalledWith({
-        vendor: undefined,
-        modelNum: undefined,
-        marketName: undefined,
-        releasedAfter: undefined,
-        releasedBefore: dateString,
+        releasedBefore: beforeDate,
         limit: 50,
         offset: 0,
       });
@@ -378,14 +302,8 @@ describe("Device GraphQL Queries", () => {
         vendor: undefined,
         modelNum: undefined,
         marketName: undefined,
-        releasedAfter:
-          typeof args.releasedAfter === "string"
-            ? args.releasedAfter
-            : args.releasedAfter?.toISOString(),
-        releasedBefore:
-          typeof args.releasedBefore === "string"
-            ? args.releasedBefore
-            : args.releasedBefore?.toISOString(),
+        releasedAfter: args.releasedAfter,
+        releasedBefore: args.releasedBefore,
         limit: args.limit ?? undefined,
         offset: args.offset ?? undefined,
       });
@@ -395,8 +313,8 @@ describe("Device GraphQL Queries", () => {
         vendor: undefined,
         modelNum: undefined,
         marketName: undefined,
-        releasedAfter: afterDate.toISOString(),
-        releasedBefore: beforeDate.toISOString(),
+        releasedAfter: afterDate,
+        releasedBefore: beforeDate,
         limit: 50,
         offset: 0,
       });

--- a/packages/backend/tests/repositories/device.repository.test.ts
+++ b/packages/backend/tests/repositories/device.repository.test.ts
@@ -142,8 +142,8 @@ describe("DeviceRepository", () => {
       mockSelect.orderBy.mockResolvedValue([device]);
 
       const result = await repository.search({
-        releasedAfter: "2023-01-01",
-        releasedBefore: "2023-12-31",
+        releasedAfter: new Date("2023-01-01"),
+        releasedBefore: new Date("2023-12-31"),
       });
 
       expect(mockSelect.where).toHaveBeenCalled();
@@ -161,7 +161,7 @@ describe("DeviceRepository", () => {
       const result = await repository.search({
         vendor: "Samsung",
         modelNum: "SM-G991",
-        releasedAfter: "2023-01-01",
+        releasedAfter: new Date("2023-01-01"),
       });
 
       expect(mockSelect.where).toHaveBeenCalled();

--- a/packages/backend/tests/repositories/software.repository.test.ts
+++ b/packages/backend/tests/repositories/software.repository.test.ts
@@ -143,7 +143,7 @@ describe("SoftwareRepository", () => {
       mockSelect.orderBy.mockResolvedValue(mockSoftware);
 
       const result = await repository.findByDevice(deviceId, {
-        releasedAfter: "2024-01-01",
+        releasedAfter: new Date("2024-01-01"),
       });
 
       expect(result[0].releaseDate).toBe("2024-06-01");
@@ -161,7 +161,7 @@ describe("SoftwareRepository", () => {
 
       const result = await repository.findByDevice(deviceId, {
         platform: "iOS",
-        releasedAfter: "2024-01-01",
+        releasedAfter: new Date("2024-01-01"),
       });
 
       expect(result[0].platform).toBe("iOS");
@@ -300,7 +300,7 @@ describe("SoftwareRepository", () => {
       mockSelect.orderBy.mockResolvedValue(mockSoftware);
 
       const result = await repository.findByDevice(1, {
-        releasedAfter: "2009-01-01",
+        releasedAfter: new Date("2009-01-01"),
       });
 
       expect(result[0].releaseDate).toBe(oldDate);


### PR DESCRIPTION
## Description
While building, I accidentally included a typing issue related to the date fields where the data could be sent as either a date or a string. This kind of loose typing makes us vulnerable to bugs. Therefore, I opted to fix this issue before it became a problem.

## Approach Taken
Updated the typing so the date processing is consistent. Then removed all conditional branches tied to casting.

## What Could Go Wrong?
Could possibly break backwards compatibility if users haven't refreshed their browsers. They'd be sending out of date requests to the backend, which wouldn't be processed correctly.

## Remediation Strategy 
Revert if needed.
