### PR TITLE
XMDEV-577: Adds query by software to device page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,3 +68,11 @@ f-types:
 .PHONY: f-test
 f-test:
 	cd packages/frontend && bun run test
+
+.PHONY: graphql-codegen
+graphql-codegen:
+	cd packages/frontend && bun run codegen
+
+.PHONY: graphql-codegen-watch
+graphql-codegen-watch:
+	cd packages/frontend && bun run codegen:watch

--- a/packages/backend/src/graphql/schema/types/device.ts
+++ b/packages/backend/src/graphql/schema/types/device.ts
@@ -62,27 +62,20 @@ DeviceType.implement({
         }),
       },
       resolve: async (device, args, ctx) => {
-        // If no specific software version, get all software and aggregate bands
-        if (!args.softwareId) {
-          const softwares = await ctx.loaders.softwareByDevice.load({
-            deviceId: device.id,
-          });
+        const softwares = await ctx.loaders.softwareByDevice.load({
+          deviceId: device.id,
+        });
 
-          if (softwares.length === 0) return [];
+        if (softwares.length === 0) return [];
 
-          // Get bands for the latest software version
-          const latestSoftware = softwares[softwares.length - 1];
-          return ctx.loaders.bandsByDeviceSoftware.load({
-            deviceId: device.id,
-            softwareId: latestSoftware.id,
-            technology: args.technology || undefined,
-          });
-        }
+        // Use provided softwareId if available, otherwise use latest software
+        const softwareId = args.softwareId
+          ? Number(args.softwareId)
+          : softwares[softwares.length - 1].id;
 
-        // Get bands for specific software version
         return ctx.loaders.bandsByDeviceSoftware.load({
           deviceId: device.id,
-          softwareId: Number(args.softwareId),
+          softwareId,
           technology: args.technology || undefined,
         });
       },

--- a/packages/frontend/src/features/devices/components/DeviceResults.tsx
+++ b/packages/frontend/src/features/devices/components/DeviceResults.tsx
@@ -24,6 +24,7 @@ import type { SelectedFields } from "./FieldSelector";
 interface DeviceResultsProps {
   deviceId: string;
   providerId: string | null;
+  softwareId: string | null;
   selectedTechnologies: string[];
   selectedFields: SelectedFields;
 }
@@ -31,6 +32,7 @@ interface DeviceResultsProps {
 export function DeviceResults({
   deviceId,
   providerId,
+  softwareId,
   selectedTechnologies,
   selectedFields,
 }: DeviceResultsProps) {
@@ -47,6 +49,7 @@ export function DeviceResults({
       // When providerId is null we skip this query, but the variable
       // is still required by the generated hook type.
       providerId: providerId ?? "",
+      softwareId: softwareId,
       bandTechnology: singleSelectedTechnology,
       comboTechnology: singleSelectedTechnology,
     },
@@ -60,6 +63,7 @@ export function DeviceResults({
   } = useGetDeviceCompleteQuery({
     variables: {
       id: deviceId,
+      softwareId: softwareId,
       bandTechnology: singleSelectedTechnology,
       comboTechnology: singleSelectedTechnology,
     },
@@ -174,6 +178,7 @@ export function DeviceResults({
 
       {/* Software Versions */}
       {selectedFields.software &&
+        softwareId === null &&
         device.software &&
         device.software.length > 0 && (
           <Card>

--- a/packages/frontend/src/features/devices/components/FieldSelector.tsx
+++ b/packages/frontend/src/features/devices/components/FieldSelector.tsx
@@ -8,6 +8,7 @@ export interface SelectedFields {
 }
 
 interface FieldSelectorProps {
+  selectedSoftwareId: string | null;
   selectedFields: SelectedFields;
   onToggleField: (field: keyof SelectedFields) => void;
 }
@@ -36,16 +37,21 @@ const FIELDS = [
 ];
 
 export function FieldSelector({
+  selectedSoftwareId,
   selectedFields,
   onToggleField,
 }: FieldSelectorProps) {
+  const visibleFields = selectedSoftwareId
+    ? FIELDS.filter((field) => field.key !== "software")
+    : FIELDS;
+
   return (
     <div>
       <label className="block text-sm font-medium text-gray-700 mb-3">
         Select Data to Display
       </label>
       <div className="space-y-3">
-        {FIELDS.map((field) => (
+        {visibleFields.map((field) => (
           <div key={field.key} className="flex items-start">
             <Checkbox
               id={`field-${field.key}`}

--- a/packages/frontend/src/features/devices/components/SoftwareSelector.tsx
+++ b/packages/frontend/src/features/devices/components/SoftwareSelector.tsx
@@ -20,6 +20,10 @@ export function SoftwareSelector({
     skip: !selectedDeviceId, // Don't query unless device is selected
   });
 
+  if (!selectedDeviceId) {
+    return null;
+  }
+
   if (loading) {
     return (
       <Card>

--- a/packages/frontend/src/features/devices/components/SoftwareSelector.tsx
+++ b/packages/frontend/src/features/devices/components/SoftwareSelector.tsx
@@ -1,0 +1,102 @@
+import { useGetDeviceQuery } from "../../../graphql/generated/graphql";
+import { Card, CardContent, Spinner } from "../../../components/ui";
+import { Globe, Code } from "lucide-react";
+
+interface SoftwareSelectorProps {
+  selectedDeviceId: string | null;
+  selectedSoftwareId: string | null;
+  onSoftwareChange: (softwareId: string | null) => void;
+}
+
+export function SoftwareSelector({
+  selectedDeviceId,
+  selectedSoftwareId,
+  onSoftwareChange,
+}: SoftwareSelectorProps) {
+  const { data, loading, error } = useGetDeviceQuery({
+    variables: {
+      id: selectedDeviceId!,
+    },
+    skip: !selectedDeviceId, // Don't query unless device is selected
+  });
+
+  if (loading) {
+    return (
+      <Card>
+        <CardContent className="py-8">
+          <Spinner size="md" className="mx-auto" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="py-4">
+          <p className="text-sm text-red-600">Error loading software</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* All Sofwares option */}
+      <button
+        onClick={() => onSoftwareChange(null)}
+        className={`p-4 rounded-lg border-2 transition-all text-left ${
+          selectedSoftwareId === null
+            ? "border-primary-500 bg-primary-50"
+            : "border-gray-200 hover:border-gray-300 hover:bg-gray-50"
+        }`}
+      >
+        <div className="flex items-center space-x-3">
+          <div className="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center flex-shrink-0">
+            <Globe className="w-5 h-5 text-blue-600" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="font-semibold text-gray-900">All software</p>
+            <p className="text-xs text-gray-600">All capabilities</p>
+          </div>
+        </div>
+      </button>
+
+      {/* Software options */}
+      {data?.device?.software?.map((software) => (
+        <button
+          key={software.id}
+          onClick={() => onSoftwareChange(software.id ?? null)}
+          className={`p-4 rounded-lg border-2 transition-all text-left ${
+            selectedSoftwareId === software.id
+              ? "border-primary-500 bg-primary-50"
+              : "border-gray-200 hover:border-gray-300 hover:bg-gray-50"
+          }`}
+        >
+          <div className="flex items-center space-x-3">
+            <div className="w-10 h-10 bg-gray-100 rounded-lg flex items-center justify-center flex-shrink-0">
+              <Code className="w-5 h-5 text-gray-600" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="font-semibold text-gray-900">{software.name}</p>
+              <div className="flex flex-col gap-0.5 mt-0.5">
+                <p className="text-xs text-gray-600">{software.platform}</p>
+                {software.buildNumber && (
+                  <p className="text-xs text-gray-500">
+                    Build: {software.buildNumber}
+                  </p>
+                )}
+                {software.releaseDate && (
+                  <p className="text-xs text-gray-500">
+                    Released:{" "}
+                    {new Date(software.releaseDate).toLocaleDateString()}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/frontend/src/graphql/generated/graphql.ts
+++ b/packages/frontend/src/graphql/generated/graphql.ts
@@ -525,6 +525,7 @@ export type GetDeviceCompleteQueryVariables = Exact<{
   id: Scalars['ID']['input'];
   bandTechnology?: InputMaybe<Scalars['String']['input']>;
   comboTechnology?: InputMaybe<Scalars['String']['input']>;
+  softwareId?: InputMaybe<Scalars['ID']['input']>;
 }>;
 
 
@@ -535,10 +536,11 @@ export type GetProviderDeviceCompleteQueryVariables = Exact<{
   providerId: Scalars['ID']['input'];
   bandTechnology?: InputMaybe<Scalars['String']['input']>;
   comboTechnology?: InputMaybe<Scalars['String']['input']>;
+  softwareId?: InputMaybe<Scalars['ID']['input']>;
 }>;
 
 
-export type GetProviderDeviceCompleteQuery = { __typename?: 'Query', device?: { __typename?: 'Device', id?: string | null, vendor?: string | null, modelNum?: string | null, marketName?: string | null, releaseDate?: string | null, software?: Array<{ __typename?: 'Software', id?: string | null, name?: string | null, platform?: string | null, buildNumber?: string | null, releaseDate?: string | null }> | null, supportedBandsForProvider?: Array<{ __typename?: 'Band', id?: string | null, bandNumber?: string | null, technology?: string | null, dlBandClass?: string | null, ulBandClass?: string | null }> | null, supportedCombosForProvider?: Array<{ __typename?: 'Combo', id?: string | null, name?: string | null, technology?: string | null }> | null, features?: Array<{ __typename?: 'Feature', id?: string | null, name?: string | null, description?: string | null }> | null } | null };
+export type GetProviderDeviceCompleteQuery = { __typename?: 'Query', device?: { __typename?: 'Device', id?: string | null, vendor?: string | null, modelNum?: string | null, marketName?: string | null, releaseDate?: string | null, software?: Array<{ __typename?: 'Software', id?: string | null, name?: string | null, platform?: string | null, buildNumber?: string | null, releaseDate?: string | null }> | null, supportedBandsForProvider?: Array<{ __typename?: 'Band', id?: string | null, bandNumber?: string | null, technology?: string | null, dlBandClass?: string | null, ulBandClass?: string | null }> | null, supportedCombosForProvider?: Array<{ __typename?: 'Combo', id?: string | null, name?: string | null, technology?: string | null }> | null, featuresForProvider?: Array<{ __typename?: 'Feature', id?: string | null, name?: string | null, description?: string | null }> | null } | null };
 
 export type GetProvidersQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1457,7 +1459,7 @@ export type GetDeviceWithProviderFeaturesLazyQueryHookResult = ReturnType<typeof
 export type GetDeviceWithProviderFeaturesSuspenseQueryHookResult = ReturnType<typeof useGetDeviceWithProviderFeaturesSuspenseQuery>;
 export type GetDeviceWithProviderFeaturesQueryResult = Apollo.QueryResult<GetDeviceWithProviderFeaturesQuery, GetDeviceWithProviderFeaturesQueryVariables>;
 export const GetDeviceCompleteDocument = gql`
-    query GetDeviceComplete($id: ID!, $bandTechnology: String, $comboTechnology: String) {
+    query GetDeviceComplete($id: ID!, $bandTechnology: String, $comboTechnology: String, $softwareId: ID) {
   device(id: $id) {
     id
     vendor
@@ -1471,19 +1473,19 @@ export const GetDeviceCompleteDocument = gql`
       buildNumber
       releaseDate
     }
-    supportedBands(technology: $bandTechnology) {
+    supportedBands(technology: $bandTechnology, softwareId: $softwareId) {
       id
       bandNumber
       technology
       dlBandClass
       ulBandClass
     }
-    supportedCombos(technology: $comboTechnology) {
+    supportedCombos(technology: $comboTechnology, softwareId: $softwareId) {
       id
       name
       technology
     }
-    features {
+    features(softwareId: $softwareId) {
       id
       name
       description
@@ -1507,6 +1509,7 @@ export const GetDeviceCompleteDocument = gql`
  *      id: // value for 'id'
  *      bandTechnology: // value for 'bandTechnology'
  *      comboTechnology: // value for 'comboTechnology'
+ *      softwareId: // value for 'softwareId'
  *   },
  * });
  */
@@ -1530,7 +1533,7 @@ export type GetDeviceCompleteLazyQueryHookResult = ReturnType<typeof useGetDevic
 export type GetDeviceCompleteSuspenseQueryHookResult = ReturnType<typeof useGetDeviceCompleteSuspenseQuery>;
 export type GetDeviceCompleteQueryResult = Apollo.QueryResult<GetDeviceCompleteQuery, GetDeviceCompleteQueryVariables>;
 export const GetProviderDeviceCompleteDocument = gql`
-    query GetProviderDeviceComplete($id: ID!, $providerId: ID!, $bandTechnology: String, $comboTechnology: String) {
+    query GetProviderDeviceComplete($id: ID!, $providerId: ID!, $bandTechnology: String, $comboTechnology: String, $softwareId: ID) {
   device(id: $id) {
     id
     vendor
@@ -1544,7 +1547,11 @@ export const GetProviderDeviceCompleteDocument = gql`
       buildNumber
       releaseDate
     }
-    supportedBandsForProvider(technology: $bandTechnology, providerId: $providerId) {
+    supportedBandsForProvider(
+      technology: $bandTechnology
+      providerId: $providerId
+      softwareId: $softwareId
+    ) {
       id
       bandNumber
       technology
@@ -1554,12 +1561,13 @@ export const GetProviderDeviceCompleteDocument = gql`
     supportedCombosForProvider(
       technology: $comboTechnology
       providerId: $providerId
+      softwareId: $softwareId
     ) {
       id
       name
       technology
     }
-    features {
+    featuresForProvider(providerId: $providerId, softwareId: $softwareId) {
       id
       name
       description
@@ -1584,6 +1592,7 @@ export const GetProviderDeviceCompleteDocument = gql`
  *      providerId: // value for 'providerId'
  *      bandTechnology: // value for 'bandTechnology'
  *      comboTechnology: // value for 'comboTechnology'
+ *      softwareId: // value for 'softwareId'
  *   },
  * });
  */

--- a/packages/frontend/src/graphql/queries/device.queries.graphql
+++ b/packages/frontend/src/graphql/queries/device.queries.graphql
@@ -67,7 +67,10 @@ query GetDeviceWithProviderBands(
     vendor
     modelNum
     marketName
-    supportedBandsForProvider(providerId: $providerId, technology: $technology) {
+    supportedBandsForProvider(
+      providerId: $providerId
+      technology: $technology
+    ) {
       id
       bandNumber
       technology
@@ -104,7 +107,10 @@ query GetDeviceWithProviderCombos(
     id
     vendor
     modelNum
-    supportedCombosForProvider(providerId: $providerId, technology: $technology) {
+    supportedCombosForProvider(
+      providerId: $providerId
+      technology: $technology
+    ) {
       id
       name
       technology
@@ -145,6 +151,7 @@ query GetDeviceComplete(
   $id: ID!
   $bandTechnology: String
   $comboTechnology: String
+  $softwareId: ID
 ) {
   device(id: $id) {
     id
@@ -152,7 +159,7 @@ query GetDeviceComplete(
     modelNum
     marketName
     releaseDate
-    
+
     software {
       id
       name
@@ -160,23 +167,23 @@ query GetDeviceComplete(
       buildNumber
       releaseDate
     }
-    
+
     # Global capabilities
-    supportedBands(technology: $bandTechnology) {
+    supportedBands(technology: $bandTechnology, softwareId: $softwareId) {
       id
       bandNumber
       technology
       dlBandClass
       ulBandClass
     }
-    
-    supportedCombos(technology: $comboTechnology) {
+
+    supportedCombos(technology: $comboTechnology, softwareId: $softwareId) {
       id
       name
       technology
     }
-    
-    features {
+
+    features(softwareId: $softwareId) {
       id
       name
       description
@@ -190,6 +197,7 @@ query GetProviderDeviceComplete(
   $providerId: ID!
   $bandTechnology: String
   $comboTechnology: String
+  $softwareId: ID
 ) {
   device(id: $id) {
     id
@@ -197,7 +205,7 @@ query GetProviderDeviceComplete(
     modelNum
     marketName
     releaseDate
-    
+
     software {
       id
       name
@@ -205,23 +213,31 @@ query GetProviderDeviceComplete(
       buildNumber
       releaseDate
     }
-    
+
     # Provider capabilities
-    supportedBandsForProvider(technology: $bandTechnology, providerId: $providerId) {
+    supportedBandsForProvider(
+      technology: $bandTechnology
+      providerId: $providerId
+      softwareId: $softwareId
+    ) {
       id
       bandNumber
       technology
       dlBandClass
       ulBandClass
     }
-    
-    supportedCombosForProvider(technology: $comboTechnology, providerId: $providerId) {
+
+    supportedCombosForProvider(
+      technology: $comboTechnology
+      providerId: $providerId
+      softwareId: $softwareId
+    ) {
       id
       name
       technology
     }
-    
-    features {
+
+    featuresForProvider(providerId: $providerId, softwareId: $softwareId) {
       id
       name
       description

--- a/packages/frontend/src/pages/DeviceQuery.tsx
+++ b/packages/frontend/src/pages/DeviceQuery.tsx
@@ -27,6 +27,11 @@ export function DeviceQueryPage() {
     features: true,
   });
 
+  const handleDeviceSelect = (deviceId: string | null) => {
+    setSelectedDeviceId(deviceId);
+    setSelectedSoftwareId(null);
+  };
+
   const handleToggleTechnology = (technology: string) => {
     setSelectedTechnologies((prev) =>
       prev.includes(technology)
@@ -71,7 +76,7 @@ export function DeviceQueryPage() {
             </CardHeader>
             <CardContent>
               <DeviceSearch
-                onDeviceSelect={setSelectedDeviceId}
+                onDeviceSelect={handleDeviceSelect}
                 selectedDeviceId={selectedDeviceId || undefined}
               />
             </CardContent>

--- a/packages/frontend/src/pages/DeviceQuery.tsx
+++ b/packages/frontend/src/pages/DeviceQuery.tsx
@@ -7,9 +7,13 @@ import { FieldSelector } from "../features/devices/components/FieldSelector";
 import type { SelectedFields } from "../features/devices/components/FieldSelector";
 import { DeviceResults } from "../features/devices/components/DeviceResults";
 import { Smartphone } from "lucide-react";
+import { SoftwareSelector } from "../features/devices/components/SoftwareSelector";
 
 export function DeviceQueryPage() {
   const [selectedDeviceId, setSelectedDeviceId] = useState<string | null>(null);
+  const [selectedSoftwareId, setSelectedSoftwareId] = useState<string | null>(
+    null
+  );
   const [selectedProviderId, setSelectedProviderId] = useState<string | null>(
     null
   );
@@ -73,11 +77,27 @@ export function DeviceQueryPage() {
             </CardContent>
           </Card>
 
+          {/* Software Selection */}
+          {selectedDeviceId && (
+            <Card>
+              <CardHeader>
+                <CardTitle>2. Select Software</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <SoftwareSelector
+                  selectedDeviceId={selectedDeviceId}
+                  selectedSoftwareId={selectedSoftwareId}
+                  onSoftwareChange={setSelectedSoftwareId}
+                />
+              </CardContent>
+            </Card>
+          )}
+
           {/* Provider Selection */}
           {selectedDeviceId && (
             <Card>
               <CardHeader>
-                <CardTitle>2. Select Provider</CardTitle>
+                <CardTitle>3. Select Provider</CardTitle>
               </CardHeader>
               <CardContent>
                 <ProviderSelector
@@ -92,7 +112,7 @@ export function DeviceQueryPage() {
           {selectedDeviceId && (
             <Card>
               <CardHeader>
-                <CardTitle>3. Filter Technologies</CardTitle>
+                <CardTitle>4. Filter Technologies</CardTitle>
               </CardHeader>
               <CardContent>
                 <TechnologyFilter
@@ -107,10 +127,11 @@ export function DeviceQueryPage() {
           {selectedDeviceId && (
             <Card>
               <CardHeader>
-                <CardTitle>4. Select Fields</CardTitle>
+                <CardTitle>5. Select Fields</CardTitle>
               </CardHeader>
               <CardContent>
                 <FieldSelector
+                  selectedSoftwareId={selectedSoftwareId}
                   selectedFields={selectedFields}
                   onToggleField={handleToggleField}
                 />
@@ -125,6 +146,7 @@ export function DeviceQueryPage() {
             <DeviceResults
               deviceId={selectedDeviceId}
               providerId={selectedProviderId}
+              softwareId={selectedSoftwareId}
               selectedTechnologies={selectedTechnologies}
               selectedFields={selectedFields}
             />

--- a/packages/frontend/tests/features/devices/components/FieldSelector.test.tsx
+++ b/packages/frontend/tests/features/devices/components/FieldSelector.test.tsx
@@ -25,9 +25,13 @@ const mixedSelection: SelectedFields = {
 
 describe("FieldSelector", () => {
   describe("Rendering", () => {
-    it("renders all field options", () => {
+    it("renders all field options when selectedSoftwareId is null", () => {
       render(
-        <FieldSelector selectedFields={allFalse} onToggleField={vi.fn()} />
+        <FieldSelector
+          selectedSoftwareId={null}
+          selectedFields={allFalse}
+          onToggleField={vi.fn()}
+        />
       );
 
       expect(screen.getByText("Software Versions")).toBeInTheDocument();
@@ -36,13 +40,111 @@ describe("FieldSelector", () => {
       expect(screen.getByText("Features")).toBeInTheDocument();
     });
 
-    it("renders a checkbox for each field", () => {
+    it("renders a checkbox for each field when selectedSoftwareId is null", () => {
       render(
-        <FieldSelector selectedFields={allFalse} onToggleField={vi.fn()} />
+        <FieldSelector
+          selectedSoftwareId={null}
+          selectedFields={allFalse}
+          onToggleField={vi.fn()}
+        />
       );
 
       const checkboxes = screen.getAllByRole("checkbox");
       expect(checkboxes).toHaveLength(4);
+    });
+
+    it("renders field descriptions", () => {
+      render(
+        <FieldSelector
+          selectedSoftwareId={null}
+          selectedFields={allFalse}
+          onToggleField={vi.fn()}
+        />
+      );
+
+      expect(
+        screen.getByText("OS versions and build numbers")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Individual frequency bands")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("LTE CA, EN-DC, NR CA combos")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("VoLTE, VoWiFi, 5G SA, etc.")
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Software field visibility based on selectedSoftwareId", () => {
+    it("shows software field when selectedSoftwareId is null", () => {
+      render(
+        <FieldSelector
+          selectedSoftwareId={null}
+          selectedFields={allFalse}
+          onToggleField={vi.fn()}
+        />
+      );
+
+      expect(screen.getByText("Software Versions")).toBeInTheDocument();
+      expect(screen.getByLabelText("Software Versions")).toBeInTheDocument();
+    });
+
+    it("hides software field when selectedSoftwareId is provided", () => {
+      render(
+        <FieldSelector
+          selectedSoftwareId="sw-1"
+          selectedFields={allFalse}
+          onToggleField={vi.fn()}
+        />
+      );
+
+      expect(screen.queryByText("Software Versions")).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Software Versions")
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders only 3 checkboxes when selectedSoftwareId is provided", () => {
+      render(
+        <FieldSelector
+          selectedSoftwareId="sw-1"
+          selectedFields={allFalse}
+          onToggleField={vi.fn()}
+        />
+      );
+
+      const checkboxes = screen.getAllByRole("checkbox");
+      expect(checkboxes).toHaveLength(3);
+    });
+
+    it("still renders other fields when software field is hidden", () => {
+      render(
+        <FieldSelector
+          selectedSoftwareId="sw-123"
+          selectedFields={allFalse}
+          onToggleField={vi.fn()}
+        />
+      );
+
+      expect(screen.getByText("Supported Bands")).toBeInTheDocument();
+      expect(screen.getByText("Carrier Aggregation")).toBeInTheDocument();
+      expect(screen.getByText("Features")).toBeInTheDocument();
+    });
+
+    it("hides software description when selectedSoftwareId is provided", () => {
+      render(
+        <FieldSelector
+          selectedSoftwareId="sw-1"
+          selectedFields={allFalse}
+          onToggleField={vi.fn()}
+        />
+      );
+
+      expect(
+        screen.queryByText("OS versions and build numbers")
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -50,17 +152,29 @@ describe("FieldSelector", () => {
     it("reflects selectedFields prop in checkbox checked state", () => {
       render(
         <FieldSelector
+          selectedSoftwareId={null}
           selectedFields={mixedSelection}
           onToggleField={vi.fn()}
         />
       );
 
       expect(screen.getByLabelText("Software Versions")).toBeChecked();
+      expect(screen.getByLabelText("Supported Bands")).not.toBeChecked();
+      expect(screen.getByLabelText("Carrier Aggregation")).toBeChecked();
+      expect(screen.getByLabelText("Features")).not.toBeChecked();
+    });
+
+    it("reflects checked state for non-software fields when software is hidden", () => {
+      render(
+        <FieldSelector
+          selectedSoftwareId="sw-1"
+          selectedFields={mixedSelection}
+          onToggleField={vi.fn()}
+        />
+      );
 
       expect(screen.getByLabelText("Supported Bands")).not.toBeChecked();
-
       expect(screen.getByLabelText("Carrier Aggregation")).toBeChecked();
-
       expect(screen.getByLabelText("Features")).not.toBeChecked();
     });
   });
@@ -72,6 +186,7 @@ describe("FieldSelector", () => {
 
       render(
         <FieldSelector
+          selectedSoftwareId={null}
           selectedFields={allFalse}
           onToggleField={onToggleField}
         />
@@ -89,6 +204,7 @@ describe("FieldSelector", () => {
 
       render(
         <FieldSelector
+          selectedSoftwareId={null}
           selectedFields={allFalse}
           onToggleField={onToggleField}
         />
@@ -100,6 +216,42 @@ describe("FieldSelector", () => {
       expect(onToggleField).toHaveBeenNthCalledWith(1, "software");
       expect(onToggleField).toHaveBeenNthCalledWith(2, "features");
     });
+
+    it("can toggle non-software fields when software field is hidden", async () => {
+      const user = userEvent.setup();
+      const onToggleField = vi.fn();
+
+      render(
+        <FieldSelector
+          selectedSoftwareId="sw-1"
+          selectedFields={allFalse}
+          onToggleField={onToggleField}
+        />
+      );
+
+      await user.click(screen.getByLabelText("Supported Bands"));
+      await user.click(screen.getByLabelText("Features"));
+
+      expect(onToggleField).toHaveBeenNthCalledWith(1, "bands");
+      expect(onToggleField).toHaveBeenNthCalledWith(2, "features");
+    });
+
+    it("can click on label text to toggle checkbox", async () => {
+      const user = userEvent.setup();
+      const onToggleField = vi.fn();
+
+      render(
+        <FieldSelector
+          selectedSoftwareId={null}
+          selectedFields={allFalse}
+          onToggleField={onToggleField}
+        />
+      );
+
+      await user.click(screen.getByText("Carrier Aggregation"));
+
+      expect(onToggleField).toHaveBeenCalledWith("combos");
+    });
   });
 
   describe("Controlled component behavior", () => {
@@ -109,6 +261,7 @@ describe("FieldSelector", () => {
 
       const { rerender } = render(
         <FieldSelector
+          selectedSoftwareId={null}
           selectedFields={allFalse}
           onToggleField={onToggleField}
         />
@@ -116,16 +269,14 @@ describe("FieldSelector", () => {
 
       const softwareCheckbox = screen.getByLabelText("Software Versions");
 
-      // Click triggers callback
       await user.click(softwareCheckbox);
       expect(onToggleField).toHaveBeenCalledWith("software");
 
-      // But checkbox remains unchecked until parent updates props
       expect(softwareCheckbox).not.toBeChecked();
 
-      // Simulate parent updating state
       rerender(
         <FieldSelector
+          selectedSoftwareId={null}
           selectedFields={{
             ...allFalse,
             software: true,
@@ -136,27 +287,100 @@ describe("FieldSelector", () => {
 
       expect(softwareCheckbox).toBeChecked();
     });
+
+    it("maintains state of other fields when selectedSoftwareId changes", async () => {
+      const onToggleField = vi.fn();
+
+      const { rerender } = render(
+        <FieldSelector
+          selectedSoftwareId={null}
+          selectedFields={{
+            software: true,
+            bands: true,
+            combos: false,
+            features: true,
+          }}
+          onToggleField={onToggleField}
+        />
+      );
+
+      expect(screen.getByLabelText("Supported Bands")).toBeChecked();
+      expect(screen.getByLabelText("Features")).toBeChecked();
+
+      rerender(
+        <FieldSelector
+          selectedSoftwareId="sw-1"
+          selectedFields={{
+            software: true,
+            bands: true,
+            combos: false,
+            features: true,
+          }}
+          onToggleField={onToggleField}
+        />
+      );
+
+      expect(screen.getByLabelText("Supported Bands")).toBeChecked();
+      expect(screen.getByLabelText("Features")).toBeChecked();
+    });
   });
 
   describe("Accessibility", () => {
     it("associates labels with checkboxes", () => {
       render(
-        <FieldSelector selectedFields={allFalse} onToggleField={vi.fn()} />
+        <FieldSelector
+          selectedSoftwareId={null}
+          selectedFields={allFalse}
+          onToggleField={vi.fn()}
+        />
       );
 
-      // If this works, label -> input association is correct
       const checkbox = screen.getByLabelText("Carrier Aggregation");
-
       expect(checkbox).toHaveAttribute("type", "checkbox");
     });
 
-    it("has no accessibility violations", async () => {
+    it("has no accessibility violations with all fields visible", async () => {
       const { container } = render(
-        <FieldSelector selectedFields={allFalse} onToggleField={vi.fn()} />
+        <FieldSelector
+          selectedSoftwareId={null}
+          selectedFields={allFalse}
+          onToggleField={vi.fn()}
+        />
       );
 
       const results = await axe(container);
       expect(results).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations when software field is hidden", async () => {
+      const { container } = render(
+        <FieldSelector
+          selectedSoftwareId="sw-1"
+          selectedFields={allFalse}
+          onToggleField={vi.fn()}
+        />
+      );
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("maintains proper label associations when software field is hidden", () => {
+      render(
+        <FieldSelector
+          selectedSoftwareId="sw-1"
+          selectedFields={allFalse}
+          onToggleField={vi.fn()}
+        />
+      );
+
+      const bandsCheckbox = screen.getByLabelText("Supported Bands");
+      const combosCheckbox = screen.getByLabelText("Carrier Aggregation");
+      const featuresCheckbox = screen.getByLabelText("Features");
+
+      expect(bandsCheckbox).toHaveAttribute("type", "checkbox");
+      expect(combosCheckbox).toHaveAttribute("type", "checkbox");
+      expect(featuresCheckbox).toHaveAttribute("type", "checkbox");
     });
   });
 });

--- a/packages/frontend/tests/features/devices/components/SoftwareSelector.test.tsx
+++ b/packages/frontend/tests/features/devices/components/SoftwareSelector.test.tsx
@@ -1,0 +1,491 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MockedProvider } from "@apollo/client/testing";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { GetDeviceDocument } from "../../../../src/graphql/generated/graphql";
+import { SoftwareSelector } from "../../../../src/features/devices/components/SoftwareSelector";
+
+expect.extend(toHaveNoViolations);
+
+const mockDeviceWithSoftware = {
+  device: {
+    id: "device-1",
+    software: [
+      {
+        id: "sw-1",
+        name: "iOS 17.0",
+        platform: "iOS",
+        buildNumber: "21A329",
+        releaseDate: "2023-09-18",
+      },
+      {
+        id: "sw-2",
+        name: "iOS 17.1",
+        platform: "iOS",
+        buildNumber: "21B74",
+        releaseDate: "2023-10-25",
+      },
+      {
+        id: "sw-3",
+        name: "iOS 17.2",
+        platform: "iOS",
+        buildNumber: "21C62",
+        releaseDate: "2023-12-11",
+      },
+    ],
+  },
+};
+
+const mockDeviceWithoutSoftware = {
+  device: {
+    id: "device-1",
+    software: [],
+  },
+};
+
+const mockDeviceWithPartialSoftwareData = {
+  device: {
+    id: "device-1",
+    software: [
+      {
+        id: "sw-1",
+        name: "Android 14",
+        platform: "Android",
+        buildNumber: null,
+        releaseDate: null,
+      },
+    ],
+  },
+};
+
+describe("SoftwareSelector", () => {
+  const defaultProps = {
+    selectedDeviceId: "device-1",
+    selectedSoftwareId: null,
+    onSoftwareChange: vi.fn(),
+  };
+
+  const createMocks = (deviceData = mockDeviceWithSoftware, overrides = {}) => [
+    {
+      request: {
+        query: GetDeviceDocument,
+        variables: {
+          id: "device-1",
+        },
+      },
+      result: {
+        data: deviceData,
+      },
+      ...overrides,
+    },
+  ];
+
+  const renderComponent = (props = {}, mocks = []) => {
+    return render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <SoftwareSelector {...defaultProps} {...props} />
+      </MockedProvider>
+    );
+  };
+
+  describe("Loading state", () => {
+    it("shows loading spinner initially", () => {
+      renderComponent({}, createMocks());
+
+      const spinner = document.querySelector(".animate-spin");
+      expect(spinner).toBeInTheDocument();
+    });
+
+    it("does not query when selectedDeviceId is null", () => {
+      const mocks = createMocks();
+      renderComponent({ selectedDeviceId: null }, mocks);
+
+      // Since skip: true, query shouldn't run and we shouldn't see loading state
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Error state", () => {
+    it("displays error message when query fails", async () => {
+      const errorMocks = [
+        {
+          request: {
+            query: GetDeviceDocument,
+            variables: {
+              id: "device-1",
+            },
+          },
+          error: new Error("Network error"),
+        },
+      ];
+
+      renderComponent({}, errorMocks);
+
+      await waitFor(() => {
+        expect(screen.getByText("Error loading software")).toBeInTheDocument();
+      });
+    });
+
+    it("error message has appropriate styling", async () => {
+      const errorMocks = [
+        {
+          request: {
+            query: GetDeviceDocument,
+            variables: {
+              id: "device-1",
+            },
+          },
+          error: new Error("Network error"),
+        },
+      ];
+
+      renderComponent({}, errorMocks);
+
+      await waitFor(() => {
+        const errorText = screen.getByText("Error loading software");
+        expect(errorText).toHaveClass("text-red-600");
+      });
+    });
+  });
+
+  describe("Rendering software options", () => {
+    it("renders 'All software' option", async () => {
+      renderComponent({}, createMocks());
+
+      await waitFor(() => {
+        expect(screen.getByText("All software")).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("All capabilities")).toBeInTheDocument();
+    });
+
+    it("renders all software versions from query", async () => {
+      renderComponent({}, createMocks());
+
+      await waitFor(() => {
+        expect(screen.getByText("iOS 17.0")).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("iOS 17.1")).toBeInTheDocument();
+      expect(screen.getByText("iOS 17.2")).toBeInTheDocument();
+    });
+
+    it("displays platform for each software version", async () => {
+      renderComponent({}, createMocks());
+
+      await waitFor(() => {
+        const platforms = screen.getAllByText("iOS");
+        expect(platforms.length).toBe(3);
+      });
+    });
+
+    it("does not display build number when null", async () => {
+      renderComponent({}, createMocks(mockDeviceWithPartialSoftwareData));
+
+      await waitFor(() => {
+        expect(screen.getByText("Android 14")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(/Build:/)).not.toBeInTheDocument();
+    });
+
+    it("does not display release date when null", async () => {
+      renderComponent({}, createMocks(mockDeviceWithPartialSoftwareData));
+
+      await waitFor(() => {
+        expect(screen.getByText("Android 14")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(/Released:/)).not.toBeInTheDocument();
+    });
+
+    it("renders only 'All software' option when device has no software", async () => {
+      renderComponent({}, createMocks(mockDeviceWithoutSoftware));
+
+      await waitFor(() => {
+        expect(screen.getByText("All software")).toBeInTheDocument();
+      });
+
+      // Should only have the "All software" button
+      const buttons = screen.getAllByRole("button");
+      expect(buttons).toHaveLength(1);
+    });
+  });
+
+  describe("Selection state", () => {
+    it("highlights 'All software' when selectedSoftwareId is null", async () => {
+      renderComponent({ selectedSoftwareId: null }, createMocks());
+
+      await waitFor(() => {
+        const allSoftwareButton = screen
+          .getByText("All software")
+          .closest("button");
+        expect(allSoftwareButton).toHaveClass(
+          "border-primary-500",
+          "bg-primary-50"
+        );
+      });
+    });
+
+    it("highlights selected software version", async () => {
+      renderComponent({ selectedSoftwareId: "sw-2" }, createMocks());
+
+      await waitFor(() => {
+        const selectedButton = screen.getByText("iOS 17.1").closest("button");
+        expect(selectedButton).toHaveClass(
+          "border-primary-500",
+          "bg-primary-50"
+        );
+      });
+    });
+
+    it("does not highlight non-selected options", async () => {
+      renderComponent({ selectedSoftwareId: "sw-2" }, createMocks());
+
+      await waitFor(() => {
+        const allSoftwareButton = screen
+          .getByText("All software")
+          .closest("button");
+        expect(allSoftwareButton).toHaveClass("border-gray-200");
+        expect(allSoftwareButton).not.toHaveClass("border-primary-500");
+      });
+
+      const otherButton = screen.getByText("iOS 17.0").closest("button");
+      expect(otherButton).toHaveClass("border-gray-200");
+      expect(otherButton).not.toHaveClass("border-primary-500");
+    });
+  });
+
+  describe("Interactions", () => {
+    it("calls onSoftwareChange with null when 'All software' is clicked", async () => {
+      const user = userEvent.setup();
+      const onSoftwareChange = vi.fn();
+
+      renderComponent({ onSoftwareChange }, createMocks());
+
+      await waitFor(() => {
+        expect(screen.getByText("All software")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("All software"));
+
+      expect(onSoftwareChange).toHaveBeenCalledTimes(1);
+      expect(onSoftwareChange).toHaveBeenCalledWith(null);
+    });
+
+    it("calls onSoftwareChange with software id when software option is clicked", async () => {
+      const user = userEvent.setup();
+      const onSoftwareChange = vi.fn();
+
+      renderComponent({ onSoftwareChange }, createMocks());
+
+      await waitFor(() => {
+        expect(screen.getByText("iOS 17.1")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("iOS 17.1"));
+
+      expect(onSoftwareChange).toHaveBeenCalledTimes(1);
+      expect(onSoftwareChange).toHaveBeenCalledWith("sw-2");
+    });
+
+    it("allows clicking different software options", async () => {
+      const user = userEvent.setup();
+      const onSoftwareChange = vi.fn();
+
+      renderComponent({ onSoftwareChange }, createMocks());
+
+      await waitFor(() => {
+        expect(screen.getByText("iOS 17.0")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("iOS 17.0"));
+      await user.click(screen.getByText("iOS 17.2"));
+
+      expect(onSoftwareChange).toHaveBeenCalledTimes(2);
+      expect(onSoftwareChange).toHaveBeenNthCalledWith(1, "sw-1");
+      expect(onSoftwareChange).toHaveBeenNthCalledWith(2, "sw-3");
+    });
+
+    it("can switch from software selection back to 'All software'", async () => {
+      const user = userEvent.setup();
+      const onSoftwareChange = vi.fn();
+
+      renderComponent(
+        { selectedSoftwareId: "sw-1", onSoftwareChange },
+        createMocks()
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("All software")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText("All software"));
+
+      expect(onSoftwareChange).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe("Controlled component behavior", () => {
+    it("does not change selection unless props change", async () => {
+      const user = userEvent.setup();
+      const onSoftwareChange = vi.fn();
+
+      const { rerender } = renderComponent(
+        { selectedSoftwareId: null, onSoftwareChange },
+        createMocks()
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("iOS 17.0")).toBeInTheDocument();
+      });
+
+      const allSoftwareButton = screen
+        .getByText("All software")
+        .closest("button");
+      expect(allSoftwareButton).toHaveClass("border-primary-500");
+
+      await user.click(screen.getByText("iOS 17.0"));
+      expect(onSoftwareChange).toHaveBeenCalledWith("sw-1");
+
+      // Selection shouldn't change until parent updates props
+      expect(allSoftwareButton).toHaveClass("border-primary-500");
+
+      // Simulate parent updating state
+      rerender(
+        <MockedProvider mocks={createMocks()} addTypename={false}>
+          <SoftwareSelector
+            {...defaultProps}
+            selectedSoftwareId="sw-1"
+            onSoftwareChange={onSoftwareChange}
+          />
+        </MockedProvider>
+      );
+
+      await waitFor(() => {
+        const selectedButton = screen.getByText("iOS 17.0").closest("button");
+        expect(selectedButton).toHaveClass("border-primary-500");
+      });
+    });
+  });
+
+  describe("Icons", () => {
+    it("displays Globe icon for 'All software' option", async () => {
+      renderComponent({}, createMocks());
+
+      await waitFor(() => {
+        expect(screen.getByText("All software")).toBeInTheDocument();
+      });
+
+      const allSoftwareButton = screen
+        .getByText("All software")
+        .closest("button");
+      const icon = allSoftwareButton?.querySelector("svg");
+      expect(icon).toBeInTheDocument();
+    });
+
+    it("displays Code icon for each software version", async () => {
+      renderComponent({}, createMocks());
+
+      await waitFor(() => {
+        expect(screen.getByText("iOS 17.0")).toBeInTheDocument();
+      });
+
+      const buttons = screen.getAllByRole("button");
+      // Exclude the first button (All software) which has Globe icon
+      const softwareButtons = buttons.slice(1);
+
+      softwareButtons.forEach((button) => {
+        const icon = button.querySelector("svg");
+        expect(icon).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("has no accessibility violations with software options", async () => {
+      const { container } = renderComponent({}, createMocks());
+
+      await waitFor(() => {
+        expect(screen.getByText("All software")).toBeInTheDocument();
+      });
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("has no accessibility violations with no software", async () => {
+      const { container } = renderComponent(
+        {},
+        createMocks(mockDeviceWithoutSoftware)
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("All software")).toBeInTheDocument();
+      });
+
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("maintains focus management during interactions", async () => {
+      const user = userEvent.setup();
+      const onSoftwareChange = vi.fn();
+
+      renderComponent({ onSoftwareChange }, createMocks());
+
+      await waitFor(() => {
+        expect(screen.getByText("iOS 17.0")).toBeInTheDocument();
+      });
+
+      const button = screen.getByText("iOS 17.0").closest("button");
+
+      if (button) {
+        await user.click(button);
+        expect(onSoftwareChange).toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe("Query behavior", () => {
+    it("passes correct device id to query", async () => {
+      const mocks = createMocks();
+      renderComponent({ selectedDeviceId: "device-1" }, mocks);
+
+      await waitFor(() => {
+        expect(screen.getByText("All software")).toBeInTheDocument();
+      });
+
+      // If we got data, the query ran with correct variables
+      expect(screen.getByText("iOS 17.0")).toBeInTheDocument();
+    });
+
+    it("skips query when device id is null", () => {
+      renderComponent({ selectedDeviceId: null }, createMocks());
+
+      // Should not show loading or data since query is skipped
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+      expect(screen.queryByText("All software")).not.toBeInTheDocument();
+    });
+
+    it("handles device with null software array", async () => {
+      const mockDeviceNullSoftware = {
+        device: {
+          id: "device-1",
+          software: null,
+        },
+      };
+
+      renderComponent({}, createMocks(mockDeviceNullSoftware));
+
+      await waitFor(() => {
+        expect(screen.getByText("All software")).toBeInTheDocument();
+      });
+
+      // Should only render "All software" option
+      const buttons = screen.getAllByRole("button");
+      expect(buttons).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Description
I wanted to add an additional level of querying that would allow users to zero in on a specific software. This PR adds that filtering.

## Approach Taken
Added a new component, associated tests and update the device query page.

## What Could Go Wrong?
Since we don't have any users yet and haven't released V1, this is still in dev. As such, not much could go wrong. If we were in a prod setting, users would need to refresh their page in order to see the latest changes.

## Remediation Strategy 
NA
