### PR TITLE
XMDEV-584: Adds DL and UL BW class filtering to band search component

### DIFF
--- a/packages/frontend/tests/features/capabilities/components/BandSearch.test.tsx
+++ b/packages/frontend/tests/features/capabilities/components/BandSearch.test.tsx
@@ -13,22 +13,36 @@ const mockBands = [
     id: "band-1",
     bandNumber: "2",
     technology: "LTE",
-    dlBandClass: "DL: 1930-1990 MHz",
-    ulBandClass: "UL: 1850-1910 MHz",
+    dlBandClass: "A",
+    ulBandClass: "A",
   },
   {
     id: "band-2",
     bandNumber: "66",
     technology: "LTE",
-    dlBandClass: "DL: 2110-2200 MHz",
-    ulBandClass: "UL: 1710-1780 MHz",
+    dlBandClass: "B",
+    ulBandClass: "A",
   },
   {
     id: "band-3",
     bandNumber: "n77",
     technology: "NR",
-    dlBandClass: "DL: 3300-4200 MHz",
-    ulBandClass: "UL: 3300-4200 MHz",
+    dlBandClass: "C",
+    ulBandClass: "B",
+  },
+  {
+    id: "band-4",
+    bandNumber: "4",
+    technology: "LTE",
+    dlBandClass: "A",
+    ulBandClass: "B",
+  },
+  {
+    id: "band-5",
+    bandNumber: "n78",
+    technology: "NR",
+    dlBandClass: null,
+    ulBandClass: null,
   },
 ];
 
@@ -61,6 +75,16 @@ const createErrorMock = (errorMessage = "Network error") => ({
   },
   error: new Error(errorMessage),
 });
+
+// Helper function to get select element by label
+const getSelectByLabel = (labelText: string): HTMLSelectElement => {
+  const label = screen.getByText(labelText);
+  const select = label.closest("div")?.querySelector("select");
+  if (!select) {
+    throw new Error(`Select with label "${labelText}" not found`);
+  }
+  return select as HTMLSelectElement;
+};
 
 describe("BandSearch", () => {
   describe("Rendering", () => {
@@ -145,28 +169,12 @@ describe("BandSearch", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Found 3 bands")).toBeInTheDocument();
+        expect(screen.getByText("Found 5 bands")).toBeInTheDocument();
       });
 
       expect(screen.getByText("Band 2")).toBeInTheDocument();
       expect(screen.getByText("Band 66")).toBeInTheDocument();
       expect(screen.getByText("Band n77")).toBeInTheDocument();
-    });
-
-    it("displays band details including technology and frequency classes", async () => {
-      render(
-        <MockedProvider mocks={[createMock()]} addTypename={false}>
-          <BandSearch onBandSelect={vi.fn()} />
-        </MockedProvider>
-      );
-
-      await waitFor(() => {
-        expect(screen.getByText("Band 2")).toBeInTheDocument();
-      });
-
-      expect(screen.getByText("DL: 1930-1990 MHz")).toBeInTheDocument();
-      expect(screen.getByText("UL: 1850-1910 MHz")).toBeInTheDocument();
-      expect(screen.getAllByText("LTE")).toHaveLength(2);
     });
 
     it("uses singular 'band' when only one result", async () => {
@@ -307,7 +315,7 @@ describe("BandSearch", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Found 3 bands")).toBeInTheDocument();
+        expect(screen.getByText("Found 5 bands")).toBeInTheDocument();
       });
 
       expect(onBandSelect).not.toHaveBeenCalled();
@@ -359,6 +367,316 @@ describe("BandSearch", () => {
     });
   });
 
+  describe("Bandwidth class filtering", () => {
+    it("renders DL and UL bandwidth class dropdowns", async () => {
+      render(
+        <MockedProvider mocks={[createMock()]} addTypename={false}>
+          <BandSearch onBandSelect={vi.fn()} />
+        </MockedProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Found 5 bands")).toBeInTheDocument();
+      });
+
+      expect(screen.getByLabelText("DL Bandwidth Class")).toBeInTheDocument();
+      expect(screen.getByLabelText("UL Bandwidth Class")).toBeInTheDocument();
+    });
+
+    it("filters bands by DL bandwidth class", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MockedProvider mocks={[createMock()]} addTypename={false}>
+          <BandSearch onBandSelect={vi.fn()} />
+        </MockedProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Found 5 bands")).toBeInTheDocument();
+      });
+
+      // Select DL bandwidth class "A"
+      const dlSelect = getSelectByLabel("DL Bandwidth Class");
+      await user.selectOptions(dlSelect, "A");
+
+      // After filtering by DL="A", we should see bands with dlBandClass="A"
+      // Expected: band-1 (A), band-4 (A) = 2 bands
+      await waitFor(() => {
+        expect(screen.getByText("Found 2 bands")).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("Band 2")).toBeInTheDocument(); // band-1
+      expect(screen.getByText("Band 4")).toBeInTheDocument(); // band-4
+      expect(screen.queryByText("Band 66")).not.toBeInTheDocument(); // band-2 (DL=B)
+      expect(screen.queryByText("Band n77")).not.toBeInTheDocument(); // band-3 (DL=C)
+    });
+
+    it("filters bands by UL bandwidth class", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MockedProvider mocks={[createMock()]} addTypename={false}>
+          <BandSearch onBandSelect={vi.fn()} />
+        </MockedProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Found 5 bands")).toBeInTheDocument();
+      });
+
+      // Select UL bandwidth class "B"
+      const ulSelect = getSelectByLabel("UL Bandwidth Class");
+      await user.selectOptions(ulSelect, "B");
+
+      // After filtering by UL="B", we should see bands with ulBandClass="B"
+      // Expected: band-3 (B), band-4 (B) = 2 bands
+      await waitFor(() => {
+        expect(screen.getByText("Found 2 bands")).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("Band n77")).toBeInTheDocument(); // band-3
+      expect(screen.getByText("Band 4")).toBeInTheDocument(); // band-4
+      expect(screen.queryByText("Band 2")).not.toBeInTheDocument(); // band-1 (UL=A)
+      expect(screen.queryByText("Band 66")).not.toBeInTheDocument(); // band-2 (UL=A)
+    });
+
+    it("filters bands by both DL and UL bandwidth classes", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MockedProvider mocks={[createMock()]} addTypename={false}>
+          <BandSearch onBandSelect={vi.fn()} />
+        </MockedProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Found 5 bands")).toBeInTheDocument();
+      });
+
+      // Select DL="A" and UL="A"
+      const dlSelect = getSelectByLabel("DL Bandwidth Class");
+      const ulSelect = getSelectByLabel("UL Bandwidth Class");
+
+      await user.selectOptions(dlSelect, "A");
+      await user.selectOptions(ulSelect, "A");
+
+      // Expected: band-1 (DL=A, UL=A) = 1 band
+      await waitFor(() => {
+        expect(screen.getByText("Found 1 band")).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("Band 2")).toBeInTheDocument(); // band-1
+      expect(screen.queryByText("Band 4")).not.toBeInTheDocument(); // band-4 (UL=B)
+      expect(screen.queryByText("Band 66")).not.toBeInTheDocument(); // band-2 (DL=B)
+    });
+
+    it("shows all bands when bandwidth class filters are cleared", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MockedProvider mocks={[createMock()]} addTypename={false}>
+          <BandSearch onBandSelect={vi.fn()} />
+        </MockedProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Found 5 bands")).toBeInTheDocument();
+      });
+
+      // Select DL="A" to filter
+      const dlSelect = getSelectByLabel("DL Bandwidth Class");
+      await user.selectOptions(dlSelect, "A");
+
+      await waitFor(() => {
+        expect(screen.getByText("Found 2 bands")).toBeInTheDocument();
+      });
+
+      // Clear filter by selecting "All"
+      await user.selectOptions(dlSelect, "");
+
+      // Should show all bands again
+      await waitFor(() => {
+        expect(screen.getByText("Found 5 bands")).toBeInTheDocument();
+      });
+    });
+
+    it("updates filtered results count when bandwidth class filter changes", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MockedProvider mocks={[createMock()]} addTypename={false}>
+          <BandSearch onBandSelect={vi.fn()} />
+        </MockedProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Found 5 bands")).toBeInTheDocument();
+      });
+
+      // Apply DL filter
+      const dlSelect = getSelectByLabel("DL Bandwidth Class");
+      await user.selectOptions(dlSelect, "B");
+
+      // Count should update to show filtered results
+      await waitFor(() => {
+        expect(screen.getByText("Found 1 band")).toBeInTheDocument();
+      });
+
+      // Change filter to "C"
+      await user.selectOptions(dlSelect, "C");
+
+      await waitFor(() => {
+        expect(screen.getByText("Found 1 band")).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("Band n77")).toBeInTheDocument(); // band-3 (DL=C)
+    });
+
+    it("filters bands correctly when both technology and bandwidth class filters are applied", async () => {
+      const user = userEvent.setup();
+      const lteBands = mockBands.filter((b) => b.technology === "LTE");
+      const mockWithTechnology = createMock(lteBands, "LTE", undefined);
+
+      render(
+        <MockedProvider
+          mocks={[createMock(), mockWithTechnology]}
+          addTypename={false}
+        >
+          <BandSearch onBandSelect={vi.fn()} />
+        </MockedProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Found 5 bands")).toBeInTheDocument();
+      });
+
+      // Select technology "LTE"
+      const techSelect = getSelectByLabel("Technology");
+      await user.selectOptions(techSelect, "LTE");
+
+      await waitFor(() => {
+        // After technology filter, should show only LTE bands (3 bands)
+        expect(screen.getByText("Found 3 bands")).toBeInTheDocument();
+      });
+
+      // Apply DL filter
+      const dlSelect = getSelectByLabel("DL Bandwidth Class");
+      await user.selectOptions(dlSelect, "A");
+
+      // Expected LTE bands with DL="A": band-1, band-4 = 2 bands
+      await waitFor(() => {
+        expect(screen.getByText("Found 2 bands")).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("Band 2")).toBeInTheDocument(); // band-1
+      expect(screen.getByText("Band 4")).toBeInTheDocument(); // band-4
+      expect(screen.queryByText("Band 66")).not.toBeInTheDocument(); // band-2 (DL=B)
+    });
+
+    it("auto-selects band when bandwidth class filtering results in single match", async () => {
+      const onBandSelect = vi.fn();
+      const user = userEvent.setup();
+      // Create bands where filtering by DL="A" and UL="A" gives only one result
+      const singleMatchBands = [
+        { ...mockBands[0], dlBandClass: "A", ulBandClass: "A" },
+        { ...mockBands[1], dlBandClass: "B", ulBandClass: "B" },
+      ];
+
+      render(
+        <MockedProvider
+          mocks={[createMock(singleMatchBands)]}
+          addTypename={false}
+        >
+          <BandSearch onBandSelect={onBandSelect} />
+        </MockedProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Found 2 bands")).toBeInTheDocument();
+      });
+
+      // Initially should not auto-select (2 bands)
+      expect(onBandSelect).not.toHaveBeenCalled();
+
+      // Filter to one result
+      const dlSelect = getSelectByLabel("DL Bandwidth Class");
+      const ulSelect = getSelectByLabel("UL Bandwidth Class");
+
+      await user.selectOptions(dlSelect, "A");
+      await user.selectOptions(ulSelect, "A");
+
+      // Should auto-select the single remaining band
+      await waitFor(() => {
+        expect(onBandSelect).toHaveBeenCalledWith("band-1");
+      });
+    });
+
+    it("excludes bands with null bandwidth classes when filtering", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MockedProvider mocks={[createMock()]} addTypename={false}>
+          <BandSearch onBandSelect={vi.fn()} />
+        </MockedProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Found 5 bands")).toBeInTheDocument();
+      });
+
+      // band-5 has null for both dlBandClass and ulBandClass
+      expect(screen.getByText("Band n78")).toBeInTheDocument(); // band-5
+
+      // When filtering by DL="A", band-5 should not appear
+      const dlSelect = getSelectByLabel("DL Bandwidth Class");
+      await user.selectOptions(dlSelect, "A");
+
+      await waitFor(() => {
+        expect(screen.getByText("Found 2 bands")).toBeInTheDocument();
+      });
+
+      // band-5 should not be in results
+      expect(screen.queryByText("Band n78")).not.toBeInTheDocument();
+    });
+
+    it("displays empty state when bandwidth class filters yield no results", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <MockedProvider mocks={[createMock()]} addTypename={false}>
+          <BandSearch onBandSelect={vi.fn()} />
+        </MockedProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Found 5 bands")).toBeInTheDocument();
+      });
+
+      // Filter by DL="A" and UL="B" - should give band-4
+      const dlSelect = getSelectByLabel("DL Bandwidth Class");
+      const ulSelect = getSelectByLabel("UL Bandwidth Class");
+
+      await user.selectOptions(dlSelect, "A");
+      await user.selectOptions(ulSelect, "B");
+
+      await waitFor(() => {
+        expect(screen.getByText("Found 1 band")).toBeInTheDocument();
+      });
+
+      // Now filter by DL="C" and UL="A" - should give no results
+      await user.selectOptions(dlSelect, "C");
+      await user.selectOptions(ulSelect, "A");
+
+      await waitFor(() => {
+        expect(screen.getByText("No bands found")).toBeInTheDocument();
+        expect(
+          screen.getByText("Try adjusting your search criteria")
+        ).toBeInTheDocument();
+      });
+    });
+  });
+
   describe("Accessibility", () => {
     it("has proper labels for form controls", () => {
       render(
@@ -369,6 +687,8 @@ describe("BandSearch", () => {
 
       expect(screen.getByLabelText("Technology")).toBeInTheDocument();
       expect(screen.getByLabelText("Band Number")).toBeInTheDocument();
+      expect(screen.getByLabelText("DL Bandwidth Class")).toBeInTheDocument();
+      expect(screen.getByLabelText("UL Bandwidth Class")).toBeInTheDocument();
     });
 
     it("band buttons are keyboard accessible", async () => {
@@ -397,7 +717,7 @@ describe("BandSearch", () => {
       );
 
       await waitFor(() => {
-        expect(screen.getByText("Found 3 bands")).toBeInTheDocument();
+        expect(screen.getByText("Found 5 bands")).toBeInTheDocument();
       });
 
       const results = await axe(container);


### PR DESCRIPTION
## Description
When on the Band Capability search page, users had a collection of options for some bands given they all had different bandwidth class combinations. This PR updates the band search to allow for filtering of dl and ul bandwidth classes to give users more flexibility.

## Approach Taken
Updated the component to filter the downlink and uplink bandwidth classes within the component, then display them.

## What Could Go Wrong?
Nothing. Principally a UI update to give users additional options when it comes to band filtering.

## Remediation Strategy 
NA
